### PR TITLE
Set position (originally was "set altitude")

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(integration_tests_runner
     async_hover.cpp
     takeoff_and_kill.cpp
     offboard_velocity.cpp
+    offboard_position.cpp
     logging.cpp
     info.cpp
     mission.cpp

--- a/integration_tests/offboard_position.cpp
+++ b/integration_tests/offboard_position.cpp
@@ -1,0 +1,152 @@
+#include <iostream>
+#include <cmath>
+#include "integration_test_helper.h"
+#include "dronecore.h"
+#include "plugins/action/action.h"
+#include "plugins/telemetry/telemetry.h"
+#include "plugins/offboard/offboard.h"
+
+using namespace dronecore;
+
+TEST_F(SitlTest, OffboardSetAltitude)
+{
+    DroneCore dc;
+
+    ConnectionResult ret = dc.add_udp_connection();
+    ASSERT_EQ(ConnectionResult::SUCCESS, ret);
+
+    // Wait for system to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    System &system = dc.system();
+    auto telemetry = std::make_shared<Telemetry>(system);
+    auto action = std::make_shared<Action>(system);
+    auto offboard = std::make_shared<Offboard>(system);
+
+    while (!telemetry->health_all_ok()) {
+        std::cout << "waiting for system to be ready" << std::endl;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    ActionResult action_ret = action->arm();
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
+
+    action_ret = action->takeoff();
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
+
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+
+    // Send it once before starting offboard, otherwise it will be rejected.
+    float altitude_m = -20.0f; // [m]
+    const float dev = 0.50f; // [m]
+    Offboard::PositionLocalNED position = {NAN, NAN, altitude_m};
+    offboard->set_position_local_ned(position);
+
+    Offboard::Result offboard_result = offboard->start();
+
+    EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
+
+    offboard->set_position_local_ned(position);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    EXPECT_GT(telemetry->position().relative_altitude_m, -altitude_m - dev);
+    EXPECT_LT(telemetry->position().relative_altitude_m, -altitude_m + dev);
+
+    altitude_m = -3.0f;
+    position = {NAN, NAN, altitude_m};
+    offboard->set_position_local_ned(position);
+    std::this_thread::sleep_for(std::chrono::seconds(20));
+    EXPECT_GT(telemetry->position().relative_altitude_m, -altitude_m - dev);
+    EXPECT_LT(telemetry->position().relative_altitude_m, -altitude_m + dev);
+
+    altitude_m = -5.0f;
+    position = {NAN, NAN, altitude_m};
+    offboard->set_position_local_ned(position);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    EXPECT_GT(telemetry->position().relative_altitude_m, -altitude_m - dev);
+    EXPECT_LT(telemetry->position().relative_altitude_m, -altitude_m + dev);
+
+    offboard_result = offboard->stop();
+    EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
+
+    action_ret = action->land();
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
+}
+
+TEST_F(SitlTest, OffboardSetPosition)
+{
+    DroneCore dc;
+
+    ConnectionResult ret = dc.add_udp_connection();
+    ASSERT_EQ(ConnectionResult::SUCCESS, ret);
+
+    // Wait for system to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    System &system = dc.system();
+
+    auto telemetry = std::make_shared<Telemetry>(system);
+    auto action = std::make_shared<Action>(system);
+    auto offboard = std::make_shared<Offboard>(system);
+
+    while (!telemetry->health_all_ok()) {
+        std::cout << "waiting for system to be ready" << std::endl;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    ActionResult action_ret = action->arm();
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
+
+    action_ret = action->takeoff();
+    ASSERT_EQ(ActionResult::SUCCESS, action_ret);
+
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+
+    // Send it once before starting offboard, otherwise it will be rejected.
+    float x = 0.0f; // [m]
+    float y = 0.0f; // [m]
+    float z = -20.0f; // [m]
+    const float dev = 0.50f; // [m]
+    Offboard::PositionLocalNED position = {x, y, z};
+    offboard->set_position_local_ned(position);
+
+    Offboard::Result offboard_result = offboard->start();
+
+    EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
+
+    offboard->set_position_local_ned(position);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    EXPECT_GT(telemetry->position().relative_altitude_m, -z - dev);
+    EXPECT_LT(telemetry->position().relative_altitude_m, -z + dev);
+
+    x = 3.0f; // [m]
+    y = 3.0f; // [m]
+    z = -3.0f; // [m]
+    position = {x, y, z};
+    offboard->set_position_local_ned(position);
+    std::this_thread::sleep_for(std::chrono::seconds(20));
+    EXPECT_GT(telemetry->position().relative_altitude_m, -z - dev);
+    EXPECT_LT(telemetry->position().relative_altitude_m, -z + dev);
+
+    x = 3.0f; // [m]
+    y = -3.0f; // [m]
+    z = -5.0f; // [m]
+    position = {x, y, z};
+    offboard->set_position_local_ned(position);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    EXPECT_GT(telemetry->position().relative_altitude_m, -z - dev);
+    EXPECT_LT(telemetry->position().relative_altitude_m, -z + dev);
+
+    x = 0.0f; // [m]
+    y = 0.0f; // [m]
+    z = -5.0f; // [m]
+    position = {x, y, z};
+    offboard->set_position_local_ned(position);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    EXPECT_GT(telemetry->position().relative_altitude_m, -z - dev);
+    EXPECT_LT(telemetry->position().relative_altitude_m, -z + dev);
+
+    offboard_result = offboard->stop();
+    EXPECT_EQ(offboard_result, Offboard::Result::SUCCESS);
+
+    action_ret = action->land();
+    EXPECT_EQ(action_ret, ActionResult::SUCCESS);
+}

--- a/plugins/offboard/offboard.cpp
+++ b/plugins/offboard/offboard.cpp
@@ -42,6 +42,11 @@ void Offboard::set_velocity_body(Offboard::VelocityBodyYawspeed velocity_body_ya
     return _impl->set_velocity_body(velocity_body_yawspeed);
 }
 
+void Offboard::set_position_local_ned(Offboard::PositionLocalNED position_local_ned)
+{
+    return _impl->set_position_local_ned(position_local_ned);
+}
+
 const char *Offboard::result_str(Result result)
 {
     switch (result) {

--- a/plugins/offboard/offboard.h
+++ b/plugins/offboard/offboard.h
@@ -94,7 +94,15 @@ public:
     };
 
     /**
-     * @brief Start offboard control (synchronous).
+     * @brief Type for position commands in NED coordinates (north, east, down).
+     */
+    struct PositionLocalNED {
+        float x_m; /**< @brief X Position in NED frame in meters.*/
+        float y_m; /**< @brief Y Position in NED frame in meters.*/
+        float z_m; /**< @brief Z Position in NED frame in meters.*/
+    };
+
+    /* @brief Start offboard control (synchronous).
      *
      * **Attention:** this is work in progress, use with caution!
      *
@@ -152,6 +160,13 @@ public:
      * @param velocity_body_yawspeed Velocity and yaw angular rate `struct`.
      */
     void set_velocity_body(VelocityBodyYawspeed velocity_body_yawspeed);
+
+    /**
+     * @brief Set the position in the local NED frame.
+     *
+     * @param position_local_ned Position 'struct'.
+     */
+    void set_position_local_ned(PositionLocalNED position_local_ned);
 
     /**
      * @brief Copy constructor (object is not copyable).

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -2,6 +2,7 @@
 #include "offboard_impl.h"
 #include "dronecore_impl.h"
 #include "px4_custom_mode.h"
+#include <cmath>
 
 namespace dronecore {
 
@@ -159,6 +160,32 @@ void OffboardImpl::set_velocity_body(Offboard::VelocityBodyYawspeed velocity_bod
     // also send it right now to reduce latency
     send_velocity_body();
 }
+void OffboardImpl::set_position_local_ned(Offboard::PositionLocalNED position_local_ned)
+{
+    _mutex.lock();
+    _position_local_ned = position_local_ned;
+
+    if (_mode != Mode::POSITION_LOCAL_NED) {
+        if (_call_every_cookie) {
+            // If we're already sending other setpoints, stop that now.
+            _parent->remove_call_every(_call_every_cookie);
+            _call_every_cookie = nullptr;
+        }
+        // We automatically send altitude setpoint from now on.
+        _parent->add_call_every(
+            [this]() { send_position_local_ned(); }, SEND_INTERVAL_S, &_call_every_cookie);
+
+        _mode = Mode::POSITION_LOCAL_NED;
+    } else {
+        // We're already sending this kind of setpoints. Since the setpoint change, let's
+        // reschedule the next call, so we don't send setpoints too often.
+        _parent->reset_call_every(_call_every_cookie);
+    }
+    _mutex.unlock();
+
+    // also send it right now to reduce latency
+    send_position_local_ned();
+}
 
 void OffboardImpl::send_velocity_ned()
 {
@@ -252,6 +279,74 @@ void OffboardImpl::send_velocity_body()
         _parent->get_autopilot_id(),
         MAV_FRAME_BODY_NED,
         IGNORE_X | IGNORE_Y | IGNORE_Z | IGNORE_AX | IGNORE_AY | IGNORE_AZ | IGNORE_YAW,
+        x,
+        y,
+        z,
+        vx,
+        vy,
+        vz,
+        afx,
+        afy,
+        afz,
+        yaw,
+        yaw_rate);
+    _parent->send_message(message);
+}
+
+void OffboardImpl::send_position_local_ned()
+{
+    _mutex.lock();
+    const float yaw = 0.0f;
+    const float yaw_rate = 0.0f;
+    float x = (float)_position_local_ned.x_m;
+    float y = (float)_position_local_ned.y_m;
+    float z = (float)_position_local_ned.z_m;
+    const float vx = 0.0f;
+    const float vy = 0.0f;
+    const float vz = 0.0f;
+    const float afx = 0.0f;
+    const float afy = 0.0f;
+    const float afz = 0.0f;
+    _mutex.unlock();
+
+    const uint16_t IGNORE_X = std::isnan(x) << 0;
+    const uint16_t IGNORE_Y = std::isnan(y) << 1;
+    const uint16_t IGNORE_Z = std::isnan(z) << 2;
+    const static uint16_t IGNORE_VX = 1 << 3;
+    const static uint16_t IGNORE_VY = 1 << 4;
+    const static uint16_t IGNORE_VZ = 1 << 5;
+    const static uint16_t IGNORE_AX = 1 << 6;
+    const static uint16_t IGNORE_AY = 1 << 7;
+    const static uint16_t IGNORE_AZ = 1 << 8;
+    const static uint16_t IS_FORCE = 0 << 9; // Setpoint is NOT a force setpoint
+    const static uint16_t IGNORE_YAW = 1 << 10;
+    const static uint16_t IGNORE_YAW_RATE = 1 << 11;
+
+    // Set values to finite values if they are not supplied since PX4 check if the values are finite
+    if (std::isnan(x)) {
+        x = 0.0f;
+    }
+    if (std::isnan(y)) {
+        y = 0.0f;
+    }
+    if (std::isnan(z)) {
+        z = 0.0f;
+    }
+
+    const static uint16_t IGNORE_MASK = IGNORE_X | IGNORE_Y | IGNORE_Z | IGNORE_VX | IGNORE_VY |
+                                        IGNORE_VZ | IGNORE_AX | IGNORE_AY | IGNORE_AZ | IS_FORCE |
+                                        IGNORE_YAW | IGNORE_YAW_RATE;
+
+    mavlink_message_t message;
+    mavlink_msg_set_position_target_local_ned_pack(
+        GCSClient::system_id,
+        GCSClient::component_id,
+        &message,
+        static_cast<uint32_t>(_parent->get_time().elapsed_s() * 1e3),
+        _parent->get_system_id(),
+        _parent->get_autopilot_id(),
+        MAV_FRAME_LOCAL_NED,
+        IGNORE_MASK,
         x,
         y,
         z,

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -29,10 +29,12 @@ public:
 
     void set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw);
     void set_velocity_body(Offboard::VelocityBodyYawspeed velocity_body_yawspeed);
+    void set_position_local_ned(Offboard::PositionLocalNED position_local_ned);
 
 private:
     void send_velocity_ned();
     void send_velocity_body();
+    void send_position_local_ned();
 
     void process_heartbeat(const mavlink_message_t &message);
     void receive_command_result(MAVLinkCommands::Result result,
@@ -43,9 +45,15 @@ private:
     void stop_sending_setpoints();
 
     mutable std::mutex _mutex{};
-    enum class Mode { NOT_ACTIVE, VELOCITY_NED, VELOCITY_BODY } _mode = Mode::NOT_ACTIVE;
+    enum class Mode {
+        NOT_ACTIVE,
+        VELOCITY_NED,
+        VELOCITY_BODY,
+        POSITION_LOCAL_NED
+    } _mode = Mode::NOT_ACTIVE;
     Offboard::VelocityNEDYaw _velocity_ned_yaw{};
     Offboard::VelocityBodyYawspeed _velocity_body_yawspeed{};
+    Offboard::PositionLocalNED _position_local_ned{};
 
     void *_call_every_cookie = nullptr;
 


### PR DESCRIPTION
This is a request for a functionality that sets the altitude through offboard control.
It requires a change in the PX4 software.
Add this in commander.cpp around line 4050 at the end of the case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
```
		control_mode.flag_control_altitude_enabled = true;
		control_mode.flag_control_attitude_enabled = true;
		control_mode.flag_control_rates_enabled = true;
		control_mode.flag_control_velocity_enabled = true;
		control_mode.flag_control_climb_rate_enabled = true;
		control_mode.flag_control_velocity_enabled = true;
```

I would like to get some feedback on this implementation because I do not know which flags I exactly need to set.