### PR TITLE
README: fix Jenkins and travis-ci badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ API consumers use the `DronecodeSDK` class to discover and manage vehicles (`Sys
 
 The links below take you to the respective header files:
 
-- [dronecore](include/dronecore.h): set up connection, discover devices
+- [dronecode_sdk](include/dronecode_sdk.h): set up connection, discover devices
 - [system](include/system.h): an class representing one drone which can consist of multiple components
 - [info](plugins/info/info.h): general info about a device
 - [telemetry](plugins/telemetry/telemetry.h): to receive telemetry data

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Dronecode SDK](https://github.com/dronecore/sdk_docs/raw/develop/assets/site/sdk_logo_full.jpg)
 
-[![jenkins build status](http://ci.px4.io:8080/buildStatus/icon?job=DroneCore/develop)](http://ci.px4.io:8080/blue/organizations/jenkins/DroneCore/activity)
-[![travis-ci build status](https://travis-ci.org/dronecore/DroneCore.svg?branch=develop)](https://travis-ci.org/dronecore/DroneCore)
+[![jenkins build status](http://ci.px4.io:8080/buildStatus/icon?job=DronecodeSDK/develop)](http://ci.px4.io:8080/blue/organizations/jenkins/DronecodeSDK/activity)
+[![travis-ci build status](https://travis-ci.org/Dronecode/DronecodeSDK.svg?branch=develop)](https://travis-ci.org/Dronecode/DronecodeSDK)
 [![appveyor build status](https://ci.appveyor.com/api/projects/status/1ntjvooywpxmoir8/branch/develop?svg=true)](https://ci.appveyor.com/project/julianoes/dronecore/branch/develop)
 [![Coverage Status](https://coveralls.io/repos/github/dronecore/DroneCore/badge.svg?branch=develop)](https://coveralls.io/github/dronecore/DroneCore?branch=develop)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![jenkins build status](http://ci.px4.io:8080/buildStatus/icon?job=DronecodeSDK/develop)](http://ci.px4.io:8080/blue/organizations/jenkins/DronecodeSDK/activity)
 [![travis-ci build status](https://travis-ci.org/Dronecode/DronecodeSDK.svg?branch=develop)](https://travis-ci.org/Dronecode/DronecodeSDK)
 [![appveyor build status](https://ci.appveyor.com/api/projects/status/1ntjvooywpxmoir8/branch/develop?svg=true)](https://ci.appveyor.com/project/julianoes/dronecore/branch/develop)
-[![Coverage Status](https://coveralls.io/repos/github/dronecore/DroneCore/badge.svg?branch=develop)](https://coveralls.io/github/dronecore/DroneCore?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/Dronecode/DronecodeSDK/badge.svg?branch=develop)](https://coveralls.io/github/Dronecode/DronecodeSDK?branch=develop)
 
 ## Description
 


### PR DESCRIPTION
Appveyor and coveralls URLs stay the same for now.

The appveyor URL just stays as far as I can see unless you tell them to change it manually.
For coveralls, ~the rename doesn't work, see https://github.com/lemurheavy/coveralls-public/issues/1156~ the rename was done manually.