### PR TITLE
action: add RTL return altitude setting

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(integration_tests_runner
     follow_me.cpp
     multi_components.cpp
     calibration.cpp
+    path_checker.cpp
     camera_take_photo.cpp
     camera_take_photo_interval.cpp
     camera_mode.cpp

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(integration_tests_runner
     mission.cpp
     mission_change_speed.cpp
     mission_survey.cpp
+    rtl.cpp
     gimbal.cpp
     transition_multicopter_fixedwing.cpp
     follow_me.cpp

--- a/integration_tests/path_checker.cpp
+++ b/integration_tests/path_checker.cpp
@@ -1,0 +1,57 @@
+#include "path_checker.h"
+#include "integration_test_helper.h"
+
+using namespace dronecode_sdk;
+
+void PathChecker::set_max_altitude(float relative_altitude_m)
+{
+    _max_altitude_m = relative_altitude_m;
+}
+
+void PathChecker::set_min_altitude(float relative_altitude_m)
+{
+    _min_altitude_m = relative_altitude_m;
+}
+
+void PathChecker::set_next_reach_altitude(float relative_altitude_m)
+{
+    _next_reach_altitude = relative_altitude_m;
+    _reached_altitude = false;
+}
+
+void PathChecker::set_margin(float margin_m)
+{
+    _margin_m = margin_m;
+}
+
+void PathChecker::check_current_alitude(float current_altitude)
+{
+    if (std::isfinite(_max_altitude_m)) {
+        EXPECT_LT(current_altitude, _max_altitude_m + _margin_m);
+    }
+
+    if (std::isfinite(_min_altitude_m)) {
+        EXPECT_GT(current_altitude, _min_altitude_m - _margin_m);
+    }
+
+    if (std::isfinite(_last_altitude_m) && std::isfinite(_next_reach_altitude)) {
+        if (std::fabs(current_altitude - _next_reach_altitude) < 2.0f * _margin_m) {
+            _reached_altitude = true;
+        }
+
+        if (!_reached_altitude && std::fabs(_next_reach_altitude - current_altitude) > _margin_m) {
+            if (_next_reach_altitude > current_altitude) {
+                EXPECT_GT(current_altitude, _last_altitude_m - _margin_m);
+            } else {
+                EXPECT_LT(current_altitude, _last_altitude_m + _margin_m);
+            }
+        }
+    }
+
+    if (!std::isfinite(_last_altitude_m)) {
+        _last_altitude_m = current_altitude;
+    } else {
+        // We some filtering, trying to get rid of noise.
+        _last_altitude_m = (_last_altitude_m * 0.8f) + (0.2f * current_altitude);
+    }
+}

--- a/integration_tests/path_checker.h
+++ b/integration_tests/path_checker.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "dronecode_sdk.h"
+#include <cmath>
+
+namespace dronecode_sdk {
+
+class PathChecker {
+public:
+    void set_max_altitude(float relative_altitude_m);
+    void set_min_altitude(float relative_altitude_m);
+    void set_next_reach_altitude(float relative_altitude_m);
+    void set_margin(float margin);
+    void check_current_alitude(float current_altitude);
+
+private:
+    float _max_altitude_m = NAN;
+    float _min_altitude_m = NAN;
+    float _next_reach_altitude = NAN;
+    float _last_altitude_m = NAN;
+    bool _reached_altitude = false;
+    float _margin_m = 1.0f;
+};
+
+} // namespace dronecode_sdk

--- a/integration_tests/rtl.cpp
+++ b/integration_tests/rtl.cpp
@@ -1,0 +1,140 @@
+#include <iostream>
+#include <functional>
+#include <memory>
+#include <future>
+#include <atomic>
+#include <cmath>
+#include "integration_test_helper.h"
+#include "dronecode_sdk.h"
+#include "plugins/telemetry/telemetry.h"
+#include "plugins/action/action.h"
+#include "plugins/mission/mission.h"
+
+using namespace dronecode_sdk;
+using namespace std::placeholders; // for `_1`
+
+// TODO: add checks that verify the return altitude
+
+void do_mission_with_rtl(float mission_altitude_m, float rtl_altitude_m);
+
+TEST_F(SitlTest, RTLHigh)
+{
+    do_mission_with_rtl(20, 30);
+}
+
+TEST_F(SitlTest, RTLLow)
+{
+    do_mission_with_rtl(5, 10);
+}
+
+TEST_F(SitlTest, RTLHigherAnyway)
+{
+    do_mission_with_rtl(10, 5);
+}
+
+void do_mission_with_rtl(float mission_altitude_m, float return_altitude_m)
+{
+    DronecodeSDK dc;
+
+    {
+        auto prom = std::make_shared<std::promise<void>>();
+        auto future_result = prom->get_future();
+
+        LogInfo() << "Waiting to discover system...";
+        dc.register_on_discover([prom](uint64_t uuid) {
+            LogInfo() << "Discovered system with UUID: " << uuid;
+            prom->set_value();
+        });
+
+        ConnectionResult ret = dc.add_udp_connection();
+        ASSERT_EQ(ret, ConnectionResult::SUCCESS);
+
+        auto status = future_result.wait_for(std::chrono::seconds(2));
+        ASSERT_EQ(status, std::future_status::ready);
+        future_result.get();
+        // FIXME: This hack is to prevent that the promise is set twice.
+        dc.register_on_discover(nullptr);
+    }
+
+    System &system = dc.system();
+    auto telemetry = std::make_shared<Telemetry>(system);
+    auto mission = std::make_shared<Mission>(system);
+    auto action = std::make_shared<Action>(system);
+
+    while (!telemetry->health_all_ok()) {
+        LogInfo() << "Waiting for system to be ready";
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    LogInfo() << "Setting RTL return altitude to " << return_altitude_m;
+    action->set_return_to_launch_return_altitude(return_altitude_m);
+
+    LogInfo() << "System ready";
+    LogInfo() << "Creating and uploading mission";
+
+    auto new_item = std::make_shared<MissionItem>();
+
+    new_item->set_position(47.398170327054473, 8.5456490218639658);
+    new_item->set_relative_altitude(mission_altitude_m);
+
+    std::vector<std::shared_ptr<MissionItem>> mission_items;
+    mission_items.push_back(new_item);
+
+    {
+        LogInfo() << "Uploading mission...";
+        auto prom = std::make_shared<std::promise<void>>();
+        auto future_result = prom->get_future();
+        mission->upload_mission_async(mission_items, [prom](Mission::Result result) {
+            ASSERT_EQ(result, Mission::Result::SUCCESS);
+            prom->set_value();
+            LogInfo() << "Mission uploaded.";
+        });
+
+        auto status = future_result.wait_for(std::chrono::seconds(2));
+        ASSERT_EQ(status, std::future_status::ready);
+        future_result.get();
+    }
+
+    LogInfo() << "Arming...";
+    const ActionResult arm_result = action->arm();
+    ASSERT_EQ(arm_result, ActionResult::SUCCESS);
+    LogInfo() << "Armed.";
+
+    // Before starting the mission, we want to be sure to subscribe to the mission progress.
+    mission->subscribe_progress([&mission](int current, int total) {
+        LogInfo() << "Mission status update: " << current << " / " << total;
+    });
+
+    {
+        LogInfo() << "Starting mission.";
+        auto prom = std::make_shared<std::promise<void>>();
+        auto future_result = prom->get_future();
+        mission->start_mission_async([prom](Mission::Result result) {
+            ASSERT_EQ(result, Mission::Result::SUCCESS);
+            prom->set_value();
+            LogInfo() << "Started mission.";
+        });
+
+        auto status = future_result.wait_for(std::chrono::seconds(2));
+        ASSERT_EQ(status, std::future_status::ready);
+        future_result.get();
+    }
+
+    while (!mission->mission_finished()) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    {
+        // We are done, and can do RTL to go home.
+        LogInfo() << "Commanding RTL...";
+        const ActionResult result = action->return_to_launch();
+        EXPECT_EQ(result, ActionResult::SUCCESS);
+        LogInfo() << "Commanded RTL.";
+    }
+
+    while (telemetry->armed()) {
+        // Wait until we're done.
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    LogInfo() << "Disarmed, exiting.";
+}

--- a/plugins/action/action.cpp
+++ b/plugins/action/action.cpp
@@ -107,4 +107,14 @@ float Action::get_max_speed_m_s() const
     return _impl->get_max_speed_m_s();
 }
 
+void Action::set_return_to_launch_return_altitude(float relative_altitude_m)
+{
+    _impl->set_return_to_launch_return_altitude(relative_altitude_m);
+}
+
+float Action::get_return_to_launch_return_altitude() const
+{
+    return _impl->get_return_to_launch_return_altitude();
+}
+
 } // namespace dronecode_sdk

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -228,7 +228,7 @@ public:
     /**
      * @brief Get the takeoff altitude.
      *
-     * @return takeoff Takeoff altitude relative to ground/takeoff location, in meters.
+     * @return Takeoff altitude relative to ground/takeoff location, in meters.
      */
     float get_takeoff_altitude_m() const;
 
@@ -246,7 +246,28 @@ public:
      */
     float get_max_speed_m_s() const;
 
-    // Non-copyable
+    /**
+     * @brief Set the return to launch minimum return altitude.
+     *
+     * When return to launch is initiated, the vehicle climbs to the return altitude if it is lower
+     * and stays at the current altitude if higher than the return altitude. Then it returns to the
+     * home location and lands there.
+     *
+     * @param relative_altitude_m Return altitude relative to takeoff location, in meters.
+     */
+    void set_return_to_launch_return_altitude(float relative_altitude_m);
+
+    /**
+     * @brief Get the return to launch minimum return altitude.
+     *
+     * When return to launch is initiated, the vehicle climbs to the return altitude if it is lower
+     * and stays at the current altitude if higher than the return altitude. Then it returns to the
+     * home location and lands there.
+     *
+     * @return Return altitude relative to takeoff location, in meters.
+     */
+    float get_return_to_launch_return_altitude() const;
+
     /**
      * @brief Copy constructor (object is not copyable).
      */

--- a/plugins/action/action.h
+++ b/plugins/action/action.h
@@ -260,9 +260,7 @@ public:
     /**
      * @brief Get the return to launch minimum return altitude.
      *
-     * When return to launch is initiated, the vehicle climbs to the return altitude if it is lower
-     * and stays at the current altitude if higher than the return altitude. Then it returns to the
-     * home location and lands there.
+     * @sa `set_return_to_launch_return_altitude`.
      *
      * @return Return altitude relative to takeoff location, in meters.
      */

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -411,21 +411,18 @@ void ActionImpl::set_takeoff_altitude(float relative_altitude_m)
 void ActionImpl::receive_takeoff_alt_param(bool success, float new_relative_altitude_m)
 {
     if (success) {
-        // TODO: This should not be buffered like this, the param system
-        //       needs some refactoring.
         _relative_takeoff_altitude_m = new_relative_altitude_m;
     }
 }
 
 float ActionImpl::get_takeoff_altitude_m() const
 {
+    // FIXME: we never actually get the param, as we should.
     return _relative_takeoff_altitude_m;
 }
 
 void ActionImpl::set_max_speed(float speed_m_s)
 {
-    // TODO: add retries
-    // const int retries = 3;
     _parent->set_param_float_async(
         "MPC_XY_CRUISE",
         speed_m_s,
@@ -441,9 +438,33 @@ void ActionImpl::receive_max_speed_result(bool success, float new_speed_m_s)
     _max_speed_m_s = new_speed_m_s;
 }
 
+void ActionImpl::receive_rtl_return_alt(bool success, float new_rtl_return_alt_m)
+{
+    if (!success) {
+        LogErr() << "setting RTL return alt failed";
+        return;
+    }
+    _rtl_return_alt_m = new_rtl_return_alt_m;
+}
+
 float ActionImpl::get_max_speed_m_s() const
 {
+    // FIXME: we never actually get the param, as we should.
     return _max_speed_m_s;
+}
+
+void ActionImpl::set_return_to_launch_return_altitude(float relative_altitude_m)
+{
+    _parent->set_param_float_async(
+        "RTL_RETURN_ALT",
+        relative_altitude_m,
+        std::bind(&ActionImpl::receive_rtl_return_alt, this, _1, relative_altitude_m));
+}
+
+float ActionImpl::get_return_to_launch_return_altitude() const
+{
+    // FIXME: we never actually get the param, as we should.
+    return _rtl_return_alt_m;
 }
 
 ActionResult ActionImpl::action_result_from_command_result(MAVLinkCommands::Result result)

--- a/plugins/action/action_impl.h
+++ b/plugins/action/action_impl.h
@@ -44,6 +44,9 @@ public:
     void set_max_speed(float speed_m_s);
     float get_max_speed_m_s() const;
 
+    void set_return_to_launch_return_altitude(float relative_altitude_m);
+    float get_return_to_launch_return_altitude() const;
+
 private:
     void loiter_before_takeoff_async(const Action::result_callback_t &callback);
     void loiter_before_arm_async(const Action::result_callback_t &callback);
@@ -60,8 +63,8 @@ private:
     void process_extended_sys_state(const mavlink_message_t &message);
 
     void receive_max_speed_result(bool success, float new_speed_m_s);
-
     void receive_takeoff_alt_param(bool success, float new_relative_altitude_m);
+    void receive_rtl_return_alt(bool success, float new_return_alt_m);
 
     static ActionResult action_result_from_command_result(MAVLinkCommands::Result result);
 
@@ -75,8 +78,8 @@ private:
     std::atomic<bool> _vtol_transition_possible{false};
 
     float _relative_takeoff_altitude_m = 2.5f;
-
     float _max_speed_m_s = NAN;
+    float _rtl_return_alt_m = NAN;
 
     static constexpr uint8_t VEHICLE_MODE_FLAG_CUSTOM_MODE_ENABLED = 1;
 };


### PR DESCRIPTION
This adds the setting to change the RTL return altitude which is the altitude at which the drone will return if RTL is engaged if it is lower (if higher, it will return at the current higher altitude).

The param system needs some refactoring in order to get this to work properly, see #440.

Todo: an integration test for this would be nice.