### PR TITLE
Gimbal accelerometer calibration

### DIFF
--- a/integration_tests/calibration.cpp
+++ b/integration_tests/calibration.cpp
@@ -85,6 +85,30 @@ TEST(HardwareTest, MagnetometerCalibration)
     }
 }
 
+TEST(HardwareTest, GimbalAccelerometerCalibration)
+{
+    DronecodeSDK dc;
+
+    ConnectionResult ret = dc.add_udp_connection();
+    ASSERT_EQ(ret, ConnectionResult::SUCCESS);
+
+    // Wait for system to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    System &system = dc.system();
+    ASSERT_TRUE(system.has_gimbal());
+
+    auto calibration = std::make_shared<Calibration>(system);
+
+    bool done = false;
+
+    calibration->calibrate_gimbal_accelerometer_async(std::bind(
+        &receive_calibration_callback, _1, _2, _3, "gimbal accelerometer", std::ref(done)));
+
+    while (!done) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+}
+
 void receive_calibration_callback(Calibration::Result result,
                                   float progress,
                                   const std::string text,

--- a/plugins/calibration/calibration.cpp
+++ b/plugins/calibration/calibration.cpp
@@ -29,6 +29,11 @@ void Calibration::calibrate_magnetometer_async(calibration_callback_t callback)
     _impl->calibrate_magnetometer_async(callback);
 }
 
+void Calibration::calibrate_gimbal_accelerometer_async(calibration_callback_t callback)
+{
+    _impl->calibrate_gimbal_accelerometer_async(callback);
+}
+
 const char *Calibration::result_str(Result result)
 {
     switch (result) {

--- a/plugins/calibration/calibration.h
+++ b/plugins/calibration/calibration.h
@@ -85,6 +85,13 @@ public:
     void calibrate_magnetometer_async(calibration_callback_t callback);
 
     /**
+     * @brief Perform gimbal accelerometer calibration (asynchronous call).
+     *
+     * @param callback Function to receive result and progress of calibration.
+     */
+    void calibrate_gimbal_accelerometer_async(calibration_callback_t callback);
+
+    /**
      * @brief Copy constructor (object is not copyable).
      */
     Calibration(const Calibration &) = delete;

--- a/plugins/calibration/calibration_impl.h
+++ b/plugins/calibration/calibration_impl.h
@@ -22,6 +22,7 @@ public:
     void calibrate_gyro_async(const Calibration::calibration_callback_t &callback);
     void calibrate_accelerometer_async(const Calibration::calibration_callback_t &callback);
     void calibrate_magnetometer_async(const Calibration::calibration_callback_t &callback);
+    void calibrate_gimbal_accelerometer_async(const Calibration::calibration_callback_t &callback);
 
     bool is_gyro_calibration_ok() const;
     bool is_accelerometer_calibration_ok() const;
@@ -67,7 +68,8 @@ private:
         NONE,
         GYRO_CALIBRATION,
         ACCELEROMETER_CALIBRATION,
-        MAGNETOMETER_CALIBRATION
+        MAGNETOMETER_CALIBRATION,
+        GIMBAL_ACCELEROMETER_CALIBRATION
     } _state;
 
     Calibration::calibration_callback_t _calibration_callback{nullptr};


### PR DESCRIPTION
This adds an API to calibrate the accelerometer of a gimbal.
The only difference to the normal accelerometer calibration is that the command is sent to the component ID of the gimbal.