### PR TITLE
cmake: remove unused include variable

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -78,7 +78,6 @@ install(FILES
     system.h
     dronecode_sdk.h
     plugin_base.h
-    ${plugin_header_paths}
     DESTINATION "include/dronecode_sdk"
 )
 


### PR DESCRIPTION
This is not used anymore. The plugin add the files to be installed themselves.