### PR TITLE
Makefile/travis: run offline tests in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,9 @@ run_all_tests: default
 run_unit_tests: default
 	build/default/unit_tests_runner
 
+run_unit_tests_offline: default
+	build/default/unit_tests_runner --gtest_filter="-CurlTest.*"
+
 run_integration_tests: default
 	build/default/integration_tests/integration_tests_runner
 

--- a/travis-docker-build.sh
+++ b/travis-docker-build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-make BUILD_TYPE=Debug run_unit_tests -j4
+make BUILD_TYPE=Debug run_unit_tests_offline -j4
 make default install
 make fix_style
 (cd example/takeoff_land && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. && make)
@@ -11,7 +11,7 @@ make fix_style
 make clean
 git clean -dfx
 
-make BUILD_TYPE=Release run_unit_tests -j4
+make BUILD_TYPE=Release run_unit_tests_offline -j4
 make default install
 make fix_style
 (cd example/takeoff_land && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make)


### PR DESCRIPTION
Internet is sometimes flaky in CI. Therefore, in order to avoid unit
tests from failing intermittently, don't run the cURL tests which
download files from s3.

Fixes #368.