### PR TITLE
Improve unit test timing

### DIFF
--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -91,10 +91,10 @@ TEST(LockedQueue, ConcurrantAccess)
 
     // The promise should not be fulfilled yet because we have not
     // returned the borrowed item.
-    auto status = fut.wait_for(std::chrono::milliseconds(10));
+    auto status = fut.wait_for(std::chrono::milliseconds(20));
     EXPECT_EQ(status, std::future_status::timeout);
 
     locked_queue.return_front();
-    status = fut.wait_for(std::chrono::milliseconds(10));
+    status = fut.wait_for(std::chrono::milliseconds(20));
     EXPECT_EQ(status, std::future_status::ready);
 }

--- a/core/thread_pool_test.cpp
+++ b/core/thread_pool_test.cpp
@@ -17,7 +17,7 @@ static Time our_time;
 
 static void run_delayed()
 {
-    our_time.sleep_for(std::chrono::milliseconds(500));
+    our_time.sleep_for(std::chrono::milliseconds(50));
     task_one_ran = true;
 }
 
@@ -29,9 +29,9 @@ TEST(ThreadPool, SimpleTask)
     task_one_ran = false;
     tp.enqueue(std::bind(run_delayed));
 
-    our_time.sleep_for(std::chrono::milliseconds(250));
+    our_time.sleep_for(std::chrono::milliseconds(25));
     EXPECT_FALSE(task_one_ran);
-    our_time.sleep_for(std::chrono::milliseconds(500));
+    our_time.sleep_for(std::chrono::milliseconds(50));
     EXPECT_TRUE(task_one_ran);
 }
 
@@ -51,7 +51,7 @@ TEST(ThreadPool, SimpleTaskWithArgs)
 
     tp.enqueue(std::bind(add_first_to_second, first, std::ref(second)));
 
-    our_time.sleep_for(std::chrono::milliseconds(250));
+    our_time.sleep_for(std::chrono::milliseconds(25));
     EXPECT_EQ(second, sum);
 }
 
@@ -66,7 +66,7 @@ TEST(ThreadPool, LambdaWithArgs)
 
     tp.enqueue([first, &second]() { second += first; });
 
-    our_time.sleep_for(std::chrono::milliseconds(250));
+    our_time.sleep_for(std::chrono::milliseconds(25));
     EXPECT_EQ(second, sum);
 }
 
@@ -82,7 +82,7 @@ TEST(ThreadPool, ManyTasks)
         tp.enqueue([&tasks, i]() { tasks[i] = i; });
     }
 
-    our_time.sleep_for(std::chrono::milliseconds(250));
+    our_time.sleep_for(std::chrono::milliseconds(25));
 
     for (int i = 0; i < tasks_num; ++i) {
         EXPECT_EQ(tasks[i], i);


### PR DESCRIPTION
This makes the thread pool test 10x faster because it was by far slowest.
On the other hand the locked queue test is slightly slowed down to prevent it from intermittently failing.