### PR TITLE
action: wait for landed state before responding

### DIFF
--- a/integration_tests/action_hover_async.cpp
+++ b/integration_tests/action_hover_async.cpp
@@ -32,13 +32,12 @@ TEST_F(SitlTest, ActionHoverAsync)
     telemetry->health_all_ok_async(std::bind(&receive_health_all_ok, _1));
     telemetry->in_air_async(std::bind(&receive_in_air, _1));
 
-    auto action = std::make_shared<Action>(system);
-
     while (!_all_ok) {
         std::cout << "Waiting to be ready..." << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
+    auto action = std::make_shared<Action>(system);
     action->arm_async(std::bind(&receive_result, _1));
     std::this_thread::sleep_for(std::chrono::seconds(2));
 

--- a/integration_tests/action_hover_sync.cpp
+++ b/integration_tests/action_hover_sync.cpp
@@ -37,7 +37,6 @@ void takeoff_and_hover_at_altitude(float altitude_m)
 
     System &system = dc.system();
     auto telemetry = std::make_shared<Telemetry>(system);
-    auto action = std::make_shared<Action>(system);
 
     int iteration = 0;
     while (!telemetry->health_all_ok()) {
@@ -47,6 +46,7 @@ void takeoff_and_hover_at_altitude(float altitude_m)
         ASSERT_LT(++iteration, 10);
     }
 
+    auto action = std::make_shared<Action>(system);
     ActionResult action_ret = action->arm();
     EXPECT_EQ(action_ret, ActionResult::SUCCESS);
     std::this_thread::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
This solves the issue where the landed state is unknown right when the action plugin is instantiated and has not received the landed state yet.

Instead of answering with an error straightaway, we can just wait for a bit hoping that we'll receive an answer.

Fixes #291.