### PR TITLE
Cleanup of methods with many arguments

### DIFF
--- a/core/system_impl.h
+++ b/core/system_impl.h
@@ -185,16 +185,13 @@ private:
     void system_thread();
     void send_heartbeat();
 
-    // Last argument will hold Flight mode command.
-    MAVLinkCommands::Result make_command_flight_mode(FlightMode mode,
-                                                     uint8_t component_id,
-                                                     MAVLinkCommands::CommandLong &command);
+    // We use std::pair instead of a std::optional.
+    std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong>
+    make_command_flight_mode(FlightMode mode, uint8_t component_id);
 
-    // Last argument will hold Set message rate command.
-    MAVLinkCommands::Result make_command_msg_rate(uint16_t message_id,
-                                                  double rate_hz,
-                                                  uint8_t component_id,
-                                                  MAVLinkCommands::CommandLong &command);
+    // We use std::pair instead of a std::optional.
+    std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong>
+    make_command_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id);
 
     static void receive_float_param(bool success,
                                     MAVLinkParameters::ParamValue value,

--- a/integration_tests/action_hover_async.cpp
+++ b/integration_tests/action_hover_async.cpp
@@ -60,7 +60,6 @@ TEST_F(SitlTest, ActionHoverAsync)
 
 void receive_result(ActionResult result)
 {
-    LogDebug() << "got result: " << unsigned(result);
     EXPECT_EQ(result, ActionResult::SUCCESS);
 }
 


### PR DESCRIPTION
This PR tries to clean up some of the methods with (too) many arguments.

The most obvious method were `make_command_flight_mode` and `make_command_msg_rate` which contained a return argument, several input arguments, as well as a by-reference output argument.

Instead of having methods with a return argument as well as by-reference output argument, it is nicer to have one std::optional as the return argument only, however, we don't have C++17 (yet) but we can use std::pair in lieu of it.
