### PR TITLE
scripts: change shebang

### DIFF
--- a/backend/tools/package_backend_framework.bash
+++ b/backend/tools/package_backend_framework.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/backend/tools/push_backend_framework_to_s3.bash
+++ b/backend/tools/push_backend_framework_to_s3.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/create_packages.sh
+++ b/create_packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fix_style.sh
+++ b/fix_style.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script runs clang-format over all files ending in .h, .c, .cpp listed
 # by git in the given directory.

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run with argument `--skip-checks` to skip checks for clean build and removing install dir.
 

--- a/start_px4_sitl.sh
+++ b/start_px4_sitl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script spawns the Gazebo PX4 software in the loop (SITL) simulation.
 # Options:

--- a/stop_px4_sitl.sh
+++ b/stop_px4_sitl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script shuts the Gazebo PX4 software in the loop (SITL) simulation down again.
 

--- a/travis-docker-build.sh
+++ b/travis-docker-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
They say use /usr/bin/env bash instead of /bin/bash because some OSs don't have bash installed or don't have it installed in /bin/bash.