### PR TITLE
core: bugfix for clearing message handlers

### DIFF
--- a/core/system_impl.cpp
+++ b/core/system_impl.cpp
@@ -91,7 +91,6 @@ void SystemImpl::unregister_all_mavlink_message_handlers(const void *cookie)
             ++it;
         }
     }
-    _mavlink_handler_table.clear();
 }
 
 void SystemImpl::register_timeout_handler(std::function<void()> callback,


### PR DESCRIPTION
This is a bugfix for a bug discovered by Jy.wang.
What happened is that when one plugin would want to clear all its
message handlers, the whole mavlink hander table gets cleared and all
other plugins and the core lose their handlers as well.

This bug only manifests itself in practice if you actually destroy a
plugin before others or the core which happens rarely since mostly
everything together is destroyed at the very end.

Fixes  #464.