### PR TITLE
hitl: assume sensor calibration ok if hitl is set

### DIFF
--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -618,9 +618,13 @@ void TelemetryImpl::receive_param_hitl(bool success, int value)
     }
 
     _hitl_enabled = (value == 1);
-    set_health_accelerometer_calibration(_hitl_enabled);
-    set_health_gyrometer_calibration(_hitl_enabled);
-    set_health_magnetometer_calibration(_hitl_enabled);
+
+    // assume sensor calibration ok in hitl
+    if (_hitl_enabled) {
+        set_health_accelerometer_calibration(_hitl_enabled);
+        set_health_gyrometer_calibration(_hitl_enabled);
+        set_health_magnetometer_calibration(_hitl_enabled);
+    }
 #ifdef LEVEL_CALIBRATION
     set_health_level_calibration(ok);
 #endif


### PR DESCRIPTION
In the current master, the health check for sensor is always set to false if hitl is not enabled. 