### PR TITLE
core: don't use colors for iOS

### DIFF
--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -39,6 +39,10 @@ if(APPLE)
     add_definitions("-DAPPLE")
 endif()
 
+if(IOS)
+    add_definitions("-DIOS")
+endif()
+
 if(UNIX AND NOT APPLE)
     add_definitions("-DLINUX")
 endif()

--- a/core/log.cpp
+++ b/core/log.cpp
@@ -44,7 +44,7 @@ void set_color(Color color)
             SetConsoleTextAttribute(handle, WIN_COLOR_RESET);
             break;
     }
-#elif defined(ANDROID)
+#elif defined(ANDROID) || defined(IOS)
     UNUSED(color);
 #else
     switch (color) {


### PR DESCRIPTION
The iOS console does not support colors, therefore we should omit the color magic.