### PR TITLE
core: allow queue items to be changed

### DIFF
--- a/core/locked_queue.h
+++ b/core/locked_queue.h
@@ -14,7 +14,7 @@ public:
     void push_back(T item)
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        _queue.push_back(item);
+        _queue.push_back(std::make_shared<T>(item));
     }
 
     // This allows to get access to the front and keep others
@@ -27,7 +27,7 @@ public:
             _mutex.unlock();
             return nullptr;
         }
-        return std::make_shared<T>(_queue.front());
+        return _queue.front();
     }
 
     // This allows to return a borrowed queue.
@@ -58,7 +58,7 @@ public:
     }
 
 private:
-    std::deque<T> _queue{};
+    std::deque<std::shared_ptr<T>> _queue{};
     std::mutex _mutex{};
 };
 

--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -98,3 +98,29 @@ TEST(LockedQueue, ConcurrantAccess)
     status = fut.wait_for(std::chrono::milliseconds(20));
     EXPECT_EQ(status, std::future_status::ready);
 }
+
+TEST(LockedQueue, ChangeValue)
+{
+    struct Item {
+        int value{42};
+    };
+
+    LockedQueue<Item> locked_queue{};
+
+    Item one;
+
+    locked_queue.push_back(one);
+
+    {
+        auto borrowed_item = locked_queue.borrow_front();
+        EXPECT_EQ(borrowed_item->value, 42);
+        borrowed_item->value = 43;
+        locked_queue.return_front();
+    }
+
+    {
+        auto borrowed_item = locked_queue.borrow_front();
+        EXPECT_EQ(borrowed_item->value, 43);
+        locked_queue.pop_front();
+    }
+}


### PR DESCRIPTION
With the old implementation, it was not possible to change the values of an item borrowed from the queue because every borrow received a new shared_ptr of a copy of the item.

By storing the items as shared_ptr from the beginning, we can solve this.