### PR TITLE
core: retry longer to get autopilot version msg

### DIFF
--- a/core/system_impl.cpp
+++ b/core/system_impl.cpp
@@ -189,7 +189,7 @@ void SystemImpl::process_heartbeat(const mavlink_message_t &message)
     if (is_autopilot(message.compid) && !have_uuid()) {
         request_autopilot_version();
 
-    } else if (!is_autopilot(message.compid) && !have_uuid() && ++_non_autopilot_heartbeats >= 2) {
+    } else if (!is_autopilot(message.compid) && !have_uuid() && ++_non_autopilot_heartbeats >= 10) {
         // We've received consecutive heartbeats (atleast twice) from a
         // non-autopilot system! Lets not delay for filling UUID anymore.
         _uuid = message.sysid;


### PR DESCRIPTION
This should resolve an error where we give up to early and therefore
never receive a autopilot version message and therefore we don't know
whether we can use the mission int mode.