### PR TITLE
build system: remove unneeded CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_INSTALL_PREFIX "../install" CACHE PATH "default cache path")
 set(CMAKE_CXX_STANDARD 11)
 
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_BINARY_DIR}/third_party)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,9 +56,9 @@ build_script:
   - md build
   - cd build
   - if "%configuration%"=="Debug" (
-      cmake -DWIN_CURL_INCLUDE_DIR:STRING="C:\curl-7.56.1\include" -DWIN_CURL_LIB:STRING="C:\curl-7.56.1\builds\libcurl-vc15-x64-debug-static-ipv6-sspi-winssl\lib\libcurl_a_debug.lib" -G "Visual Studio 15 2017 Win64" ..
+      cmake -DWIN_CURL_INCLUDE_DIR:STRING="C:\curl-7.56.1\include" -DWIN_CURL_LIB:STRING="C:\curl-7.56.1\builds\libcurl-vc15-x64-debug-static-ipv6-sspi-winssl\lib\libcurl_a_debug.lib" -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=..\install ..
     ) else (
-      cmake -DWIN_CURL_INCLUDE_DIR:STRING="C:\curl-7.56.1\include" -DWIN_CURL_LIB:STRING="C:\curl-7.56.1\builds\libcurl-vc15-x64-release-static-ipv6-sspi-winssl\lib\libcurl_a.lib" -G "Visual Studio 15 2017 Win64" ..
+      cmake -DWIN_CURL_INCLUDE_DIR:STRING="C:\curl-7.56.1\include" -DWIN_CURL_LIB:STRING="C:\curl-7.56.1\builds\libcurl-vc15-x64-release-static-ipv6-sspi-winssl\lib\libcurl_a.lib" -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=..\install ..
     )
   - if "%configuration%"=="Debug" (
       cmake --build . --target install --config Debug


### PR DESCRIPTION
We can set the CMAKE_INSTALL_PREFIX using the Makefile anyway, and this default here is actually not needed.