### PR TITLE
Add camera descriptions

### DIFF
--- a/backend/src/plugins/camera/camera_service_impl.h
+++ b/backend/src/plugins/camera/camera_service_impl.h
@@ -539,6 +539,7 @@ public:
                                  rpc::camera::Setting *rpc_setting)
     {
         rpc_setting->set_setting_id(setting.setting_id);
+        rpc_setting->set_setting_description(setting.setting_description);
         rpc_setting->set_allocated_option(translateOption(setting.option).release());
     }
 
@@ -547,6 +548,7 @@ public:
     {
         auto rpc_option = std::unique_ptr<rpc::camera::Option>(new rpc::camera::Option);
         rpc_option->set_option_id(option.option_id);
+        rpc_option->set_option_description(option.option_description);
 
         return rpc_option;
     }
@@ -556,6 +558,7 @@ public:
     {
         dronecode_sdk::Camera::Setting setting;
         setting.setting_id = rpc_setting.setting_id();
+        setting.setting_description = rpc_setting.setting_description();
         setting.option = translateRPCOption(rpc_setting.option());
 
         return setting;
@@ -565,6 +568,7 @@ public:
     {
         dronecode_sdk::Camera::Option option;
         option.option_id = rpc_option.option_id();
+        option.option_description = rpc_option.option_description();
 
         return option;
     }

--- a/integration_tests/camera_settings.cpp
+++ b/integration_tests/camera_settings.cpp
@@ -221,17 +221,6 @@ TEST(CameraTest, SetSettings)
         EXPECT_EQ(set_setting(camera, "CAM_EXPMODE", "0"), Camera::Result::SUCCESS);
         EXPECT_EQ(get_setting(camera, "CAM_EXPMODE", value_set), Camera::Result::SUCCESS);
         EXPECT_STREQ("0", value_set.c_str());
-
-        // Check human readable strings too.
-        std::string description;
-        EXPECT_FALSE(camera->get_setting_str("BLABLIBLU", description));
-        EXPECT_STREQ(description.c_str(), "");
-
-        EXPECT_TRUE(camera->get_setting_str("CAM_EXPMODE", description));
-        EXPECT_STREQ(description.c_str(), "Exposure Mode");
-
-        EXPECT_TRUE(camera->get_setting_str("CAM_SHUTTERSPD", description));
-        EXPECT_STREQ(description.c_str(), "Shutter Speed");
     }
 }
 
@@ -241,8 +230,15 @@ static void receive_current_settings(bool &subscription_called,
     LogDebug() << "Received current options:";
     EXPECT_TRUE(settings.size() > 0);
     for (auto &setting : settings) {
-        LogDebug() << "Got setting '" << setting.setting_id << "' with selected option '"
-                   << setting.option.option_id << "'";
+        LogDebug() << "Got setting '" << setting.setting_description << "' with selected option '"
+                   << setting.option.option_description << "'";
+
+        // Check human readable strings too.
+        if (setting.setting_id == "CAM_SHUTTERSPD") {
+            EXPECT_STREQ(setting.setting_id.c_str(), "Shutter Speed");
+        } else if (setting.setting_id == "CAM_EXPMODE") {
+            EXPECT_STREQ(setting.setting_id.c_str(), "Exposure Mode");
+        }
     }
     subscription_called = true;
 }
@@ -291,7 +287,12 @@ receive_possible_setting_options(bool &subscription_called,
         LogDebug() << "Got setting '" << setting_options.setting_id << "' with options:";
         EXPECT_TRUE(setting_options.options.size() > 0);
         for (auto &option : setting_options.options) {
-            LogDebug() << " - '" << option.option_id << "'";
+            LogDebug() << " - '" << option.option_description << "'";
+            if (setting_options.setting_id == "Shutter Speed" && option.option_id == "0.0025") {
+                EXPECT_STREQ(option.option_description.c_str(), "1/400");
+            } else if (setting_options.setting_id == "CAM_WBMODE" && option.option_id == "1") {
+                EXPECT_STREQ(option.option_description.c_str(), "Sunrise");
+            }
         }
     }
     subscription_called = true;

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -150,18 +150,6 @@ bool Camera::get_possible_options(const std::string &setting_id,
     return _impl->get_possible_options(setting_id, options);
 }
 
-bool Camera::get_setting_str(const std::string &setting_id, std::string &description)
-{
-    return _impl->get_setting_str(setting_id, description);
-}
-
-bool Camera::get_option_str(const std::string &setting_id,
-                            const std::string &option_id,
-                            std::string &description)
-{
-    return _impl->get_option_str(setting_id, option_id, description);
-}
-
 void Camera::subscribe_current_settings(const subscribe_current_settings_callback_t &callback)
 {
     _impl->subscribe_current_settings(callback);
@@ -323,22 +311,26 @@ std::ostream &operator<<(std::ostream &str, Camera::Status::StorageStatus const 
 
 bool operator==(const Camera::Setting &lhs, const Camera::Setting &rhs)
 {
-    return lhs.setting_id == rhs.setting_id && lhs.option == rhs.option;
+    return lhs.setting_id == rhs.setting_id && lhs.setting_description == rhs.setting_description &&
+           lhs.option == rhs.option;
 }
 
 std::ostream &operator<<(std::ostream &str, Camera::Setting const &setting)
 {
-    return str << "[setting_id: " << setting.setting_id << ", option: " << setting.option << "]";
+    return str << "[setting_id: " << setting.setting_id
+               << ", setting_description: " << setting.setting_description
+               << ", option: " << setting.option << "]";
 }
 
 bool operator==(const Camera::Option &lhs, const Camera::Option &rhs)
 {
-    return lhs.option_id == rhs.option_id;
+    return (lhs.option_id == rhs.option_id) && (lhs.option_description == rhs.option_description);
 }
 
 std::ostream &operator<<(std::ostream &str, Camera::Option const &option)
 {
-    return str << "[option_id: " << option.option_id << "]";
+    return str << "[option_id: " << option.option_id
+               << ", option_description: " << option.option_description << "]";
 }
 
 bool operator==(const Camera::SettingOptions &lhs, const Camera::SettingOptions &rhs)

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -1029,6 +1029,7 @@ bool CameraImpl::get_possible_options(const std::string &setting_id,
         ss << value;
         Camera::Option option;
         option.option_id = ss.str();
+        get_option_str(setting_id, option.option_id, option.option_description);
         options.push_back(option);
     }
 
@@ -1132,6 +1133,7 @@ void CameraImpl::get_option_async(const std::string &setting_id,
         if (callback) {
             Camera::Option new_option{};
             new_option.option_id = value.get_string();
+            get_option_str(setting_id, new_option.option_id, new_option.option_description);
             callback(Camera::Result::SUCCESS, new_option);
         }
     } else {
@@ -1194,7 +1196,10 @@ void CameraImpl::notify_current_settings()
         if (_camera_definition->get_setting(possible_setting, value)) {
             Camera::Setting setting;
             setting.setting_id = possible_setting;
+            get_setting_str(setting.setting_id, setting.setting_description);
             setting.option.option_id = value.get_string();
+            get_option_str(
+                setting.setting_id, setting.option.option_id, setting.option.option_description);
             current_settings.push_back(setting);
         }
     }

--- a/plugins/camera/include/plugins/camera/camera.h
+++ b/plugins/camera/include/plugins/camera/camera.h
@@ -432,6 +432,7 @@ public:
      */
     struct Option {
         std::string option_id; /**< Name of the option (machine readable). */
+        std::string option_description; /**< Description of the description (human readable). */
     };
 
     /**
@@ -439,6 +440,7 @@ public:
      */
     struct Setting {
         std::string setting_id; /**< Name of the setting (machine readable). */
+        std::string setting_description; /**< Description of the setting (human readable). */
         Option option; /**< Selected option. */
     };
 
@@ -453,11 +455,6 @@ public:
     /**
      * @brief Get settings that can be changed.
      *
-     * The list of settings consists of machine readable parameters,
-     * for a human readable desription of the setting use get_setting_str().
-     *
-     * @sa `get_setting_str`
-     *
      * @param settings List of settings that can be changed.
      * @return true request was successful.
      */
@@ -465,11 +462,6 @@ public:
 
     /**
      * @brief Get possible options for a setting that can be selected.
-     *
-     * The list of options consists of machine readable option values,
-     * for a human readable description of the option use get_option_str().
-     *
-     * @sa `get_option_str`
      *
      * @param setting_id Name of setting (machine readable).
      * @param options List of `Option` objects to select from.
@@ -535,27 +527,6 @@ public:
      */
     void subscribe_possible_setting_options(
         const subscribe_possible_setting_options_callback_t &callback);
-
-    /**
-     * @brief Get the human readable string of a setting.
-     *
-     * @param setting_id The machine readable setting name.
-     * @param description The human readable string of the setting to get.
-     * @return true if call was successful and the description has been set.
-     */
-    bool get_setting_str(const std::string &setting_id, std::string &description);
-
-    /**
-     * @brief Get the human readable string of an option.
-     *
-     * @param setting_id The machine readable setting name.
-     * @param option_id The machine readable option value.
-     * @param description The human readable string of the option to get.
-     * @return true if call was successful and the description has been set.
-     */
-    bool get_option_str(const std::string &setting_id,
-                        const std::string &option_id,
-                        std::string &description);
 
     /**
      * @brief Copy constructor (object is not copyable).


### PR DESCRIPTION
Instead of having separate helpers, we now just include it in the Option and Setting structs.