### PR TITLE
camera: add setting option description

### DIFF
--- a/backend/src/plugins/camera/camera_service_impl.h
+++ b/backend/src/plugins/camera/camera_service_impl.h
@@ -608,6 +608,7 @@ public:
                                         rpc::camera::SettingOptions *rpc_setting_options)
     {
         rpc_setting_options->set_setting_id(setting_options.setting_id);
+        rpc_setting_options->set_setting_description(setting_options.setting_description);
 
         for (const auto option : setting_options.options) {
             auto rpc_option = rpc_setting_options->add_options();
@@ -620,6 +621,7 @@ public:
     {
         dronecode_sdk::Camera::SettingOptions setting_options;
         setting_options.setting_id = rpc_setting_options.setting_id();
+        setting_options.setting_description = rpc_setting_options.setting_description();
 
         std::vector<dronecode_sdk::Camera::Option> options;
         for (auto option : rpc_setting_options.options()) {

--- a/backend/test/camera_service_impl_test.cpp
+++ b/backend/test/camera_service_impl_test.cpp
@@ -119,6 +119,7 @@ protected:
 
     dronecode_sdk::Camera::SettingOptions
     createSettingOptions(const std::string setting_id,
+                         const std::string setting_description,
                          const std::vector<dronecode_sdk::Camera::Option> &options) const;
     std::future<void> subscribePossibleSettingOptionsAsync(
         std::vector<std::vector<dronecode_sdk::Camera::SettingOptions>> &possible_settings_events,
@@ -1056,7 +1057,8 @@ TEST_F(CameraServiceImplTest, registersToPossibleSettings)
     std::vector<dronecode_sdk::Camera::SettingOptions> possible_settings;
     std::vector<dronecode_sdk::Camera::Option> options;
     options.push_back(createOption(ARBITRARY_OPTION_ID));
-    possible_settings.push_back(createSettingOptions(ARBITRARY_SETTING_ID, options));
+    possible_settings.push_back(
+        createSettingOptions(ARBITRARY_SETTING_ID, ARBITRARY_SETTING_DESCRIPTION, options));
     dronecode_sdk::Camera::subscribe_possible_setting_options_callback_t possible_settings_callback;
     EXPECT_CALL(_camera, subscribe_possible_setting_options(_))
         .WillOnce(SaveResult(&possible_settings_callback, &_callback_saved_promise));
@@ -1072,10 +1074,13 @@ TEST_F(CameraServiceImplTest, registersToPossibleSettings)
 }
 
 dronecode_sdk::Camera::SettingOptions CameraServiceImplTest::createSettingOptions(
-    const std::string setting_id, const std::vector<dronecode_sdk::Camera::Option> &options) const
+    const std::string setting_id,
+    const std::string setting_description,
+    const std::vector<dronecode_sdk::Camera::Option> &options) const
 {
     dronecode_sdk::Camera::SettingOptions setting_options;
     setting_options.setting_id = setting_id;
+    setting_options.setting_description = setting_description;
     setting_options.options = options;
 
     return setting_options;
@@ -1125,7 +1130,8 @@ TEST_F(CameraServiceImplTest, sendsOnePossibleSettingOptions)
     std::vector<dronecode_sdk::Camera::SettingOptions> possible_setting_options;
     std::vector<dronecode_sdk::Camera::Option> options;
     options.push_back(createOption(ARBITRARY_OPTION_ID));
-    possible_setting_options.push_back(createSettingOptions(ARBITRARY_SETTING_ID, options));
+    possible_setting_options.push_back(
+        createSettingOptions(ARBITRARY_SETTING_ID, ARBITRARY_SETTING_DESCRIPTION, options));
     possible_setting_options_events.push_back(possible_setting_options);
 
     checkSendsPossibleSettingOptions(possible_setting_options_events);
@@ -1157,7 +1163,7 @@ void CameraServiceImplTest::checkSendsPossibleSettingOptions(
     std::vector<dronecode_sdk::Camera::Option> options;
     options.push_back(createOption(ARBITRARY_OPTION_ID));
     arbitrary_possible_setting_options.push_back(
-        createSettingOptions(ARBITRARY_SETTING_ID, options));
+        createSettingOptions(ARBITRARY_SETTING_ID, ARBITRARY_SETTING_DESCRIPTION, options));
     possible_setting_options_callback(arbitrary_possible_setting_options);
     possible_setting_options_events_future.wait();
 
@@ -1183,11 +1189,11 @@ TEST_F(CameraServiceImplTest, sendsMultiplePossibleSettingOptionss)
     options1.push_back(createOption("option1_1"));
     options1.push_back(createOption("option1_2"));
     options1.push_back(createOption("option1_3"));
-    possible_setting_options.push_back(createSettingOptions("setting1", options1));
+    possible_setting_options.push_back(createSettingOptions("setting1", "Setting one", options1));
     std::vector<dronecode_sdk::Camera::Option> options2;
     options2.push_back(createOption("option1"));
     options2.push_back(createOption("option2"));
-    possible_setting_options.push_back(createSettingOptions("setting2", options2));
+    possible_setting_options.push_back(createSettingOptions("setting2", "Setting two", options2));
 
     std::vector<dronecode_sdk::Camera::Option> options3;
     options3.push_back(createOption("option1"));
@@ -1195,7 +1201,7 @@ TEST_F(CameraServiceImplTest, sendsMultiplePossibleSettingOptionss)
     options3.push_back(createOption("option2"));
     options3.push_back(createOption("option1"));
     options3.push_back(createOption("option1"));
-    possible_setting_options.push_back(createSettingOptions("setting3", options3));
+    possible_setting_options.push_back(createSettingOptions("setting3", "Setting Three", options3));
 
     possible_setting_options_events.push_back(possible_setting_options);
 

--- a/integration_tests/camera_settings.cpp
+++ b/integration_tests/camera_settings.cpp
@@ -296,7 +296,7 @@ receive_possible_setting_options(bool &subscription_called,
         EXPECT_TRUE(setting_options.options.size() > 0);
         for (auto &option : setting_options.options) {
             LogDebug() << " - '" << option.option_description << "'";
-            if (setting_options.setting_id == "Shutter Speed" && option.option_id == "0.0025") {
+            if (setting_options.setting_id == "CAM_SHUTTERSPD" && option.option_id == "0.0025") {
                 EXPECT_STREQ(option.option_description.c_str(), "1/400");
             } else if (setting_options.setting_id == "CAM_WBMODE" && option.option_id == "2") {
                 EXPECT_STREQ(option.option_description.c_str(), "Sunrise");

--- a/integration_tests/camera_settings.cpp
+++ b/integration_tests/camera_settings.cpp
@@ -285,6 +285,14 @@ receive_possible_setting_options(bool &subscription_called,
     EXPECT_TRUE(settings_options.size() > 0);
     for (auto &setting_options : settings_options) {
         LogDebug() << "Got setting '" << setting_options.setting_id << "' with options:";
+
+        // Check human readable strings too.
+        if (setting_options.setting_id == "CAM_SHUTTERSPD") {
+            EXPECT_STREQ(setting_options.setting_description.c_str(), "Shutter Speed");
+        } else if (setting_options.setting_id == "CAM_EXPMODE") {
+            EXPECT_STREQ(setting_options.setting_description.c_str(), "Exposure Mode");
+        }
+
         EXPECT_TRUE(setting_options.options.size() > 0);
         for (auto &option : setting_options.options) {
             LogDebug() << " - '" << option.option_description << "'";

--- a/plugins/camera/camera.cpp
+++ b/plugins/camera/camera.cpp
@@ -345,7 +345,7 @@ bool operator==(const Camera::SettingOptions &lhs, const Camera::SettingOptions 
         }
     }
 
-    return lhs.setting_id == rhs.setting_id;
+    return lhs.setting_id == rhs.setting_id && lhs.setting_description == rhs.setting_description;
 }
 
 std::ostream &operator<<(std::ostream &str, Camera::SettingOptions const &setting_options)

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -22,6 +22,26 @@ CameraImpl::CameraImpl(System &system) : PluginImplBase(system)
 CameraImpl::~CameraImpl()
 {
     _parent->unregister_plugin(this);
+
+    {
+        std::lock_guard<std::mutex> lock(_status.mutex);
+        _status.callback = nullptr;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(_get_mode.mutex);
+        _get_mode.callback = nullptr;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(_capture_info.mutex);
+        _capture_info.callback = nullptr;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(_video_stream_info.mutex);
+        _video_stream_info.callback = nullptr;
+    }
 }
 
 void CameraImpl::init()

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -1228,6 +1228,7 @@ void CameraImpl::notify_possible_setting_options()
     for (auto &possible_setting : possible_settings) {
         Camera::SettingOptions setting_options;
         setting_options.setting_id = possible_setting;
+        get_setting_str(setting_options.setting_id, setting_options.setting_description);
         get_possible_options(possible_setting, setting_options.options);
         possible_setting_options.push_back(setting_options);
     }

--- a/plugins/camera/include/plugins/camera/camera.h
+++ b/plugins/camera/include/plugins/camera/camera.h
@@ -449,6 +449,7 @@ public:
      */
     struct SettingOptions {
         std::string setting_id; /**< Name of the setting (machine readable). */
+        std::string setting_description; /**< Description of the setting (human readable). */
         std::vector<Option> options; /**< List of options. */
     };
 


### PR DESCRIPTION
This should address a couple of camera issues:

- Added missing setting option description (reported by @douglaswsilva).
- Double free / segfault on exit.
- Fixed camera settings integration test.