### PR TITLE
mission: interim fix for crash on mission progress

### DIFF
--- a/backend/cmake/MacOSXFrameworkInfo.plist.in
+++ b/backend/cmake/MacOSXFrameworkInfo.plist.in
@@ -17,7 +17,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.1</string>
+	<string>0.1.2</string>
         <key>MinimumOSVersion</key>
         <string>11.3</string>
 	<key>CSResourcesFileMapped</key>

--- a/backend/src/plugins/mission/mission_service_impl.h
+++ b/backend/src/plugins/mission/mission_service_impl.h
@@ -287,9 +287,11 @@ private:
             rpc_mission_progress_response.set_mission_count(total);
             writer->Write(rpc_mission_progress_response);
 
-            if (current == total - 1) {
-                mission_finished_promise.set_value();
-            }
+            // FIXME: It is possible that we get this progress update multiple times. If this
+            //        happens, we fulfill the promise more than once which leads to a crash.
+            // if (current == total - 1) {
+            //    mission_finished_promise.set_value();
+            //}
         });
 
         mission_finished_future.wait();

--- a/backend/tools/push_backend_framework_to_s3.bash
+++ b/backend/tools/push_backend_framework_to_s3.bash
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FAT_BIN_DIR=${SCRIPT_DIR}/../../build/fat_bin
-CURRENT_VERSION=0.1.1
+CURRENT_VERSION=0.1.2
 
 aws s3 cp ${FAT_BIN_DIR}/dronecode-backend.zip s3://dronecode-sdk/dronecode-backend-latest.zip
 aws s3api put-object-acl --bucket dronecode-sdk --key dronecode-backend-latest.zip --acl public-read


### PR DESCRIPTION
The reason for the crash was probably that we fulfilled the promise more than once. Therefore, let's just never stop giving updates like we do it for telemetry as well.