### PR TITLE
Another try to fix mission progress crash

### DIFF
--- a/backend/cmake/MacOSXFrameworkInfo.plist.in
+++ b/backend/cmake/MacOSXFrameworkInfo.plist.in
@@ -17,7 +17,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.2</string>
+	<string>0.1.3</string>
         <key>MinimumOSVersion</key>
         <string>11.3</string>
 	<key>CSResourcesFileMapped</key>

--- a/backend/src/plugins/mission/mission_service_impl.h
+++ b/backend/src/plugins/mission/mission_service_impl.h
@@ -281,7 +281,7 @@ private:
         std::promise<void> mission_finished_promise;
         auto mission_finished_future = mission_finished_promise.get_future();
 
-        _mission.subscribe_progress([&writer, &mission_finished_promise](int current, int total) {
+        _mission.subscribe_progress([&writer](int current, int total) {
             dronecode_sdk::rpc::mission::MissionProgressResponse rpc_mission_progress_response;
             rpc_mission_progress_response.set_current_item_index(current);
             rpc_mission_progress_response.set_mission_count(total);

--- a/backend/tools/push_backend_framework_to_s3.bash
+++ b/backend/tools/push_backend_framework_to_s3.bash
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FAT_BIN_DIR=${SCRIPT_DIR}/../../build/fat_bin
-CURRENT_VERSION=0.1.2
+CURRENT_VERSION=0.1.3
 
 aws s3 cp ${FAT_BIN_DIR}/dronecode-backend.zip s3://dronecode-sdk/dronecode-backend-latest.zip
 aws s3api put-object-acl --bucket dronecode-sdk --key dronecode-backend-latest.zip --acl public-read

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -111,6 +111,8 @@ private:
         Mission::result_callback_t result_callback{nullptr};
         Mission::mission_items_and_result_callback_t mission_items_and_result_callback{nullptr};
         Mission::progress_callback_t progress_callback{nullptr};
+        int last_current_reported_mission_item{-1};
+        int last_total_reported_mission_item{-1};
     } _mission_data{};
 
     void *_timeout_cookie{nullptr};


### PR DESCRIPTION
The filtering was done to early and meant that we would send mission progress with equal values in rapid succession. Presumably this triggered a crash in the backend.

The error in GRPC was: `GRPC_CALL_ERROR_TOO_MANY_OPERATIONS`.