### PR TITLE
mission: added RTL after a mission is complete

### DIFF
--- a/plugins/mission/include/plugins/mission/mission.h
+++ b/plugins/mission/include/plugins/mission/mission.h
@@ -118,6 +118,27 @@ public:
     void download_mission_async(mission_items_and_result_callback_t callback);
 
     /**
+     * @brief Set whether to trigger Return-to-Launch (RTL) after mission is complete.
+     *
+     * This enables/disables to command RTL at the end of a mission.
+     *
+     * @note After setting this option, the mission needs to be re-uploaded.
+     *
+     * @param enable Enables RTL after mission is complete.
+     */
+    void set_return_to_launch_after_mission(bool enable);
+
+    /**
+     * @brief Get whether to trigger Return-to-Launch (RTL) after mission is complete.
+     *
+     * @note Before getting this option, it needs to be set, or a mission
+     *       needs to be downloaded.
+     *
+     * @return True if RTL after mission is complete is enabled.
+     */
+    bool get_return_to_launch_after_mission();
+
+    /**
      * @brief Starts the mission (asynchronous).
      *
      * Note that the mission must be uploaded to the vehicle using `upload_mission_async()` before

--- a/plugins/mission/mission.cpp
+++ b/plugins/mission/mission.cpp
@@ -20,6 +20,16 @@ void Mission::download_mission_async(Mission::mission_items_and_result_callback_
     _impl->download_mission_async(callback);
 }
 
+void Mission::set_return_to_launch_after_mission(bool enable)
+{
+    _impl->set_return_to_launch_after_mission(enable);
+}
+
+bool Mission::get_return_to_launch_after_mission()
+{
+    return _impl->get_return_to_launch_after_mission();
+}
+
 void Mission::start_mission_async(result_callback_t callback)
 {
     _impl->start_mission_async(callback);

--- a/plugins/mission/mission_impl.h
+++ b/plugins/mission/mission_impl.h
@@ -30,6 +30,9 @@ public:
 
     void download_mission_async(const Mission::mission_items_and_result_callback_t &callback);
 
+    void set_return_to_launch_after_mission(bool enable_rtl);
+    bool get_return_to_launch_after_mission();
+
     void start_mission_async(const Mission::result_callback_t &callback);
     void pause_mission_async(const Mission::result_callback_t &callback);
 
@@ -116,6 +119,8 @@ private:
     } _mission_data{};
 
     void *_timeout_cookie{nullptr};
+
+    bool _enable_return_to_launch_after_mission{false};
 
     static constexpr unsigned MAX_RETRIES = 3;
 


### PR DESCRIPTION
This adds the option to set/get whether RTL should automatically be executed at the end of a mission.