### PR TITLE
core: disable fallback to system ID for now

### DIFF
--- a/core/system_impl.cpp
+++ b/core/system_impl.cpp
@@ -424,6 +424,7 @@ void SystemImpl::request_autopilot_version()
         return;
     }
 
+#if defined(ENABLE_FALLBACK_TO_SYSTEM_ID)
     if (!_autopilot_version_pending && _uuid_retries >= 3) {
         // We give up getting a UUID and use the system ID.
 
@@ -433,6 +434,7 @@ void SystemImpl::request_autopilot_version()
         set_connected();
         return;
     }
+#endif
 
     _autopilot_version_pending = true;
 
@@ -444,7 +446,9 @@ void SystemImpl::request_autopilot_version()
     command.target_component_id = get_autopilot_id();
 
     send_command_async(command, nullptr);
+#if defined(ENABLE_FALLBACK_TO_SYSTEM_ID)
     ++_uuid_retries;
+#endif
 
     // We set a timeout to stay "pending" for half a second. This way, we don't give up too
     // early e.g. because multiple components send heartbeats and we receive them all at once

--- a/core/system_impl.h
+++ b/core/system_impl.h
@@ -17,6 +17,9 @@
 #include <mutex>
 #include <future>
 
+// TODO: Figure out what to do with systems without UUID.
+//#define ENABLE_FALLBACK_TO_SYSTEM_ID
+
 namespace dronecode_sdk {
 
 class DronecodeSDKImpl;
@@ -225,7 +228,9 @@ private:
 
     uint64_t _uuid{0};
 
+#if defined(ENABLE_FALLBACK_TO_SYSTEM_ID)
     int _uuid_retries = 0;
+#endif
     std::atomic<bool> _uuid_initialized{false};
 
     uint8_t _non_autopilot_heartbeats = 0;


### PR DESCRIPTION
The fallback to system ID causes problems on systems with multiple
components that might answer but do not actually mean that a vehicle is
connected. For instance the remote controller might also send heartbeats
and trigger a discovery event when really the drone is not discovered
(yet).

In the future we might add an option for UUID vs. system ID but for now
this should resolve the issues described.