### PR TITLE
telemetry: only listen to autopilot for armed flag

### DIFF
--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -491,6 +491,10 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t &message)
 
 void TelemetryImpl::process_heartbeat(const mavlink_message_t &message)
 {
+    if (message.compid != MAV_COMP_ID_AUTOPILOT1) {
+        return;
+    }
+
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
 


### PR DESCRIPTION
If we listen to the heartbeats from all components the armed flag will flicker. Therefore let's filter by component ID.