### PR TITLE
camera: fix notification if current options change

### DIFF
--- a/backend/cmake/MacOSXFrameworkInfo.plist.in
+++ b/backend/cmake/MacOSXFrameworkInfo.plist.in
@@ -17,7 +17,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>0.2.1</string>
         <key>MinimumOSVersion</key>
         <string>11.3</string>
 	<key>CSResourcesFileMapped</key>

--- a/backend/tools/push_backend_framework_to_s3.bash
+++ b/backend/tools/push_backend_framework_to_s3.bash
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FAT_BIN_DIR=${SCRIPT_DIR}/../../build/fat_bin
-CURRENT_VERSION=0.2.0
+CURRENT_VERSION=0.2.1
 
 aws s3 cp ${FAT_BIN_DIR}/dronecode-backend.zip s3://dronecode-sdk/dronecode-backend-latest.zip
 aws s3api put-object-acl --bucket dronecode-sdk --key dronecode-backend-latest.zip --acl public-read

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -1337,6 +1337,10 @@ void CameraImpl::refresh_params()
 
     std::vector<std::string> params{};
     if (!_camera_definition->get_unknown_params(params)) {
+        // We're assuming that we changed one option and this did not cause
+        // any other possible settings to change. However, we still would
+        // like to notify the current settings with this one change.
+        notify_current_settings();
         return;
     }
 


### PR DESCRIPTION
This should resolve the error where we don't receive the new current
settings when changing one current setting that does not cause any other
settings to change.