### PR TITLE
Fix settings notification again

### DIFF
--- a/backend/cmake/MacOSXFrameworkInfo.plist.in
+++ b/backend/cmake/MacOSXFrameworkInfo.plist.in
@@ -17,7 +17,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.4</string>
+	<string>0.2.5</string>
         <key>MinimumOSVersion</key>
         <string>11.3</string>
 	<key>CSResourcesFileMapped</key>

--- a/backend/tools/push_backend_framework_to_s3.bash
+++ b/backend/tools/push_backend_framework_to_s3.bash
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FAT_BIN_DIR=${SCRIPT_DIR}/../../build/fat_bin
-CURRENT_VERSION=0.2.4
+CURRENT_VERSION=0.2.5
 
 aws s3 cp ${FAT_BIN_DIR}/dronecode-backend.zip s3://dronecode-sdk/dronecode-backend-latest.zip
 aws s3api put-object-acl --bucket dronecode-sdk --key dronecode-backend-latest.zip --acl public-read

--- a/integration_tests/camera_settings.cpp
+++ b/integration_tests/camera_settings.cpp
@@ -64,7 +64,7 @@ TEST(CameraTest, ShowSettingsAndOptions)
         }
 
         if (is_e90) {
-            EXPECT_EQ(settings.size(), 6);
+            EXPECT_EQ(settings.size(), 7);
         } else if (is_e50) {
             EXPECT_EQ(settings.size(), 5);
         } else if (is_et) {

--- a/integration_tests/camera_settings.cpp
+++ b/integration_tests/camera_settings.cpp
@@ -144,6 +144,14 @@ TEST(CameraTest, SetSettings)
         EXPECT_EQ(get_setting(camera, "CAM_COLORMODE", value_set), Camera::Result::SUCCESS);
         EXPECT_STREQ("5", value_set.c_str());
 
+        EXPECT_EQ(set_setting(camera, "CAM_COLORMODE", "1"), Camera::Result::SUCCESS);
+        EXPECT_EQ(get_setting(camera, "CAM_COLORMODE", value_set), Camera::Result::SUCCESS);
+        EXPECT_STREQ("1", value_set.c_str());
+
+        EXPECT_EQ(set_setting(camera, "CAM_COLORMODE", "3"), Camera::Result::SUCCESS);
+        EXPECT_EQ(get_setting(camera, "CAM_COLORMODE", value_set), Camera::Result::SUCCESS);
+        EXPECT_STREQ("3", value_set.c_str());
+
         // Let's check the manual exposure mode first.
         std::this_thread::sleep_for(std::chrono::seconds(2));
         EXPECT_EQ(set_setting(camera, "CAM_EXPMODE", "1"), Camera::Result::SUCCESS);

--- a/plugins/camera/camera_definition.cpp
+++ b/plugins/camera/camera_definition.cpp
@@ -542,7 +542,7 @@ bool CameraDefinition::get_possible_options(const std::string &name,
     return true;
 }
 
-bool CameraDefinition::get_unknown_params(std::vector<std::string> &params)
+void CameraDefinition::get_unknown_params(std::vector<std::string> &params)
 {
     params.clear();
 
@@ -551,7 +551,6 @@ bool CameraDefinition::get_unknown_params(std::vector<std::string> &params)
             params.push_back(parameter.first);
         }
     }
-    return true;
 }
 
 void CameraDefinition::set_all_params_unknown()

--- a/plugins/camera/camera_definition.h
+++ b/plugins/camera/camera_definition.h
@@ -45,7 +45,7 @@ public:
                         const std::string &option_name,
                         std::string &description);
 
-    bool get_unknown_params(std::vector<std::string> &params);
+    void get_unknown_params(std::vector<std::string> &params);
     void set_all_params_unknown();
 
     // Non-copyable

--- a/plugins/camera/camera_definition_test.cpp
+++ b/plugins/camera/camera_definition_test.cpp
@@ -282,7 +282,7 @@ TEST(CameraDefinition, E90SettingsToUpdate)
 
     {
         std::vector<std::string> params;
-        EXPECT_TRUE(cd.get_unknown_params(params));
+        cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 16);
         for (const auto &param : params) {
             LogInfo() << param;
@@ -298,7 +298,7 @@ TEST(CameraDefinition, E90SettingsToUpdate)
     // Now that we set one param it should be less that we need to fetch.
     {
         std::vector<std::string> params;
-        EXPECT_TRUE(cd.get_unknown_params(params));
+        cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 15);
     }
 
@@ -306,7 +306,7 @@ TEST(CameraDefinition, E90SettingsToUpdate)
 
     {
         std::vector<std::string> params;
-        EXPECT_TRUE(cd.get_unknown_params(params));
+        cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 16);
     }
 }
@@ -321,7 +321,7 @@ TEST(CameraDefinition, E90SettingsCauseUpdates)
 
     {
         std::vector<std::string> params;
-        EXPECT_TRUE(cd.get_unknown_params(params));
+        cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 0);
         for (const auto &param : params) {
             LogInfo() << param;
@@ -337,7 +337,7 @@ TEST(CameraDefinition, E90SettingsCauseUpdates)
     // Now that we set one param it should be less that we need to fetch.
     {
         std::vector<std::string> params;
-        EXPECT_TRUE(cd.get_unknown_params(params));
+        cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 4);
 
         // TODO: improve the poor man's vector search.

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -1336,7 +1336,8 @@ void CameraImpl::refresh_params()
     }
 
     std::vector<std::string> params{};
-    if (!_camera_definition->get_unknown_params(params)) {
+    _camera_definition->get_unknown_params(params);
+    if (params.size() == 0) {
         // We're assuming that we changed one option and this did not cause
         // any other possible settings to change. However, we still would
         // like to notify the current settings with this one change.


### PR DESCRIPTION
This resolves the issue where the current settings were not notified
after color mode was updated. This happened because color mode does
not lead to any other setting changes except the color mode itself.
In this case `get_unknown_params()` would not find any unknown params
but still return true. The right solution is to get rid of the confusing
return argument and just check the size of the params vector directly.

This is the correct fix instead of #524.