### PR TITLE
fix SIGSEGV in is_connected() when no system is connected

### DIFF
--- a/core/dronecode_sdk_impl.cpp
+++ b/core/dronecode_sdk_impl.cpp
@@ -255,6 +255,10 @@ bool DronecodeSDKImpl::is_connected() const
 {
     std::lock_guard<std::recursive_mutex> lock(_systems_mutex);
 
+    if (_systems.empty()) {
+        return false;
+    }
+
     return _systems.begin()->second->is_connected();
 }
 


### PR DESCRIPTION
Fixes an issue in which if an application (e.g., offboard_velocity) is started
before the simulator is started, a segmentation fault is caused because it
tries to dereference a null pointer.

Signed-off-by: Gabriel Moreno <gabrielm@cs.cmu.edu>