### PR TITLE
Add sudo to Docker development image.

### DIFF
--- a/docker/Dockerfile-Fedora-27
+++ b/docker/Dockerfile-Fedora-27
@@ -30,6 +30,7 @@ RUN dnf -y install \
     which \
     zlib-devel \
     golang \
+    sudo \
     && dnf clean all
 
 RUN wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-Fedora27.tar.xz \
@@ -40,6 +41,9 @@ RUN wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-Fedora
 RUN gem install --no-ri --no-rdoc fpm;
 
 RUN useradd -d /home/dronecode -m -s /bin/bash dronecode
+
+ADD /sudoers.txt /etc/sudoers
+RUN chmod 440 /etc/sudoers
 
 USER dronecode
 

--- a/docker/Dockerfile-Fedora-28
+++ b/docker/Dockerfile-Fedora-28
@@ -30,11 +30,15 @@ RUN dnf -y install \
     which \
     zlib-devel \
     golang \
+    sudo \
     && dnf clean all
 
 RUN gem install --no-ri --no-rdoc fpm;
 
 RUN useradd -d /home/dronecode -m -s /bin/bash dronecode
+
+ADD /sudoers.txt /etc/sudoers
+RUN chmod 440 /etc/sudoers
 
 USER dronecode
 

--- a/docker/Dockerfile-Ubuntu-16.04
+++ b/docker/Dockerfile-Ubuntu-16.04
@@ -32,6 +32,7 @@ RUN apt-get update \
         wget \
         libz-dev \
         golang-go \
+        sudo \
     && apt-get -y autoremove \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
@@ -46,6 +47,9 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
 RUN gem install --no-ri --no-rdoc fpm;
 
 RUN useradd -d /home/dronecode -m -s /bin/bash dronecode
+
+ADD /sudoers.txt /etc/sudoers
+RUN chmod 440 /etc/sudoers
 
 USER dronecode
 

--- a/docker/Dockerfile-Ubuntu-18.04
+++ b/docker/Dockerfile-Ubuntu-18.04
@@ -32,6 +32,7 @@ RUN apt-get update \
         ruby-dev \
         libz-dev \
         golang-go \
+        sudo \
     && apt-get -y autoremove \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
@@ -41,6 +42,9 @@ RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/cl
 RUN gem install --no-ri --no-rdoc fpm;
 
 RUN useradd -d /home/dronecode -m -s /bin/bash dronecode
+
+ADD /sudoers.txt /etc/sudoers
+RUN chmod 440 /etc/sudoers
 
 USER dronecode
 

--- a/docker/sudoers.txt
+++ b/docker/sudoers.txt
@@ -1,0 +1,2 @@
+root ALL=(ALL) ALL
+dronecode ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
Add sudo so that root commands can be used now docker image defaults to normal user.

Davids-MacBook-Pro:DronecodeSDK dave$ ./run-docker.sh
dronecode@host:~/DronecodeSDK$ make default

dronecode@host:~/DronecodeSDK$ sudo make default install

dronecode@host:~/DronecodeSDK$ sudo ldconfig

dronecode@host:~/DronecodeSDK$ cd example/takeoff_land/build

dronecode@host:~/DronecodeSDK/example/takeoff_land/build$ make
