### PR TITLE
calibration: return only one struct (and the result)

### DIFF
--- a/backend/src/CMakeLists.txt
+++ b/backend/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 
-set(COMPONENTS_LIST core action camera mission telemetry)
+set(COMPONENTS_LIST core action calibration camera mission telemetry)
 
 include(cmake/compile_proto.cmake)
 
@@ -37,6 +37,7 @@ endif()
 target_link_libraries(backend
     dronecode_sdk
     dronecode_sdk_action
+    dronecode_sdk_calibration
     dronecode_sdk_camera
     dronecode_sdk_mission
     dronecode_sdk_telemetry

--- a/backend/src/grpc_server.h
+++ b/backend/src/grpc_server.h
@@ -5,6 +5,8 @@
 
 #include "plugins/action/action.h"
 #include "action/action_service_impl.h"
+#include "plugins/calibration/calibration.h"
+#include "calibration/calibration_service_impl.h"
 #include "plugins/camera/camera.h"
 #include "camera/camera_service_impl.h"
 #include "core/core_service_impl.h"

--- a/backend/src/plugins/calibration/calibration_service_impl.h
+++ b/backend/src/plugins/calibration/calibration_service_impl.h
@@ -1,0 +1,167 @@
+#include <future>
+
+#include "plugins/calibration/calibration.h"
+#include "calibration/calibration.grpc.pb.h"
+
+namespace dronecode_sdk {
+namespace backend {
+
+template<typename Calibration = Calibration>
+class CalibrationServiceImpl final : public rpc::calibration::CalibrationService::Service {
+public:
+    CalibrationServiceImpl(Calibration &calibration) : _calibration(calibration) {}
+
+    static std::unique_ptr<rpc::calibration::CalibrationResult>
+    translateCalibrationResult(const dronecode_sdk::Calibration::Result &calibration_result)
+    {
+        auto rpc_calibration_result = std::unique_ptr<rpc::calibration::CalibrationResult>(
+            new rpc::calibration::CalibrationResult());
+
+        auto rpc_result =
+            static_cast<rpc::calibration::CalibrationResult::Result>(calibration_result);
+        rpc_calibration_result->set_result(rpc_result);
+        rpc_calibration_result->set_result_str(
+            dronecode_sdk::Calibration::result_str(calibration_result));
+
+        return rpc_calibration_result;
+    }
+
+    static std::unique_ptr<rpc::calibration::ProgressData>
+    translateProgressData(const dronecode_sdk::Calibration::ProgressData &progress_data)
+    {
+        auto rpc_progress_data =
+            std::unique_ptr<rpc::calibration::ProgressData>(new rpc::calibration::ProgressData());
+
+        rpc_progress_data->set_has_progress(progress_data.has_progress);
+        rpc_progress_data->set_progress(progress_data.progress);
+        rpc_progress_data->set_has_status_text(progress_data.has_status_text);
+        rpc_progress_data->set_status_text(progress_data.status_text);
+
+        return rpc_progress_data;
+    }
+
+    grpc::Status
+    CalibrateGyro(grpc::ServerContext * /* context */,
+                  const rpc::calibration::CalibrateGyroRequest request,
+                  grpc::ServerWriter<rpc::calibration::CalibrateGyroResponse> *writer) override
+    {
+        std::promise<void> stream_closed_promise;
+        auto stream_closed_future = stream_closed_promise.get_future();
+
+        bool is_finished = false;
+
+        _calibration.calibrate_gyro_async([this, &writer, &stream_closed_promise, &is_finished](
+                                              const dronecode_sdk::Calibration::Result result,
+                                              const float progress,
+                                              const std::string &status_text) {
+            rpc::calibration::CalibrateGyroResponse rpc_response;
+            rpc_response.set_allocated_calibration_result(translateCalibrationResult(result).get());
+
+            std::lock_guard<std::mutex> lock(_subscribe_mutex);
+            if (!writer->Write(rpc_response) && !is_finished) {
+                is_finished = true;
+                stream_closed_promise.set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        return grpc::Status::OK;
+    }
+
+    grpc::Status CalibrateAccelerometer(
+        grpc::ServerContext * /* context */,
+        const rpc::calibration::CalibrateAccelerometerRequest request,
+        grpc::ServerWriter<rpc::calibration::CalibrateAccelerometerResponse> *writer) override
+    {
+        std::promise<void> stream_closed_promise;
+        auto stream_closed_future = stream_closed_promise.get_future();
+
+        bool is_finished = false;
+
+        _calibration.calibrate_accelerometer_async(
+            [this, &writer, &stream_closed_promise, &is_finished](
+                const dronecode_sdk::Calibration::Result result,
+                const float progress,
+                const std::string &status_text) {
+                rpc::calibration::CalibrateAccelerometerResponse rpc_response;
+                rpc_response.set_allocated_calibration_result(
+                    translateCalibrationResult(result).get());
+
+                std::lock_guard<std::mutex> lock(_subscribe_mutex);
+                if (!writer->Write(rpc_response) && !is_finished) {
+                    is_finished = true;
+                    stream_closed_promise.set_value();
+                }
+            });
+
+        stream_closed_future.wait();
+        return grpc::Status::OK;
+    }
+
+    grpc::Status CalibrateMagnetometer(
+        grpc::ServerContext * /* context */,
+        const rpc::calibration::CalibrateMagnetometerRequest request,
+        grpc::ServerWriter<rpc::calibration::CalibrateMagnetometerResponse> *writer) override
+    {
+        std::promise<void> stream_closed_promise;
+        auto stream_closed_future = stream_closed_promise.get_future();
+
+        bool is_finished = false;
+
+        _calibration.calibrate_magnetometer_async(
+            [this, &writer, &stream_closed_promise, &is_finished](
+                const dronecode_sdk::Calibration::Result result,
+                const float progress,
+                const std::string &status_text) {
+                rpc::calibration::CalibrateMagnetometerResponse rpc_response;
+                rpc_response.set_allocated_calibration_result(
+                    translateCalibrationResult(result).get());
+
+                std::lock_guard<std::mutex> lock(_subscribe_mutex);
+                if (!writer->Write(rpc_response) && !is_finished) {
+                    is_finished = true;
+                    stream_closed_promise.set_value();
+                }
+            });
+
+        stream_closed_future.wait();
+        return grpc::Status::OK;
+    }
+
+    grpc::Status CalibrateGimbalAccelerometer(
+        grpc::ServerContext * /* context */,
+        const rpc::calibration::CalibrateGimbalAccelerometerRequest request,
+        grpc::ServerWriter<rpc::calibration::CalibrateGimbalAccelerometerResponse> *writer) override
+    {
+        std::promise<void> stream_closed_promise;
+        auto stream_closed_future = stream_closed_promise.get_future();
+
+        bool is_finished = false;
+
+        _calibration.calibrate_gimbal_accelerometer_async(
+            [this, &writer, &stream_closed_promise, &is_finished](
+                const dronecode_sdk::Calibration::Result result,
+                const float progress,
+                const std::string &status_text) {
+                rpc::calibration::CalibrateGimbalAccelerometerResponse rpc_response;
+                rpc_response.set_allocated_calibration_result(
+                    translateCalibrationResult(result).get());
+
+                std::lock_guard<std::mutex> lock(_subscribe_mutex);
+                if (!writer->Write(rpc_response) && !is_finished) {
+                    is_finished = true;
+                    stream_closed_promise.set_value();
+                }
+            });
+
+        stream_closed_future.wait();
+        return grpc::Status::OK;
+    }
+
+private:
+    Calibration &_calibration;
+    std::mutex _subscribe_mutex{};
+};
+
+} // namespace backend
+} // namespace dronecode_sdk

--- a/integration_tests/calibration.cpp
+++ b/integration_tests/calibration.cpp
@@ -7,7 +7,7 @@
 using namespace dronecode_sdk;
 using namespace std::placeholders; // for `_1`
 
-static void receive_calibration_callback(const Calibration::Result &result,
+static void receive_calibration_callback(const Calibration::Result result,
                                          const Calibration::ProgressData &progress_data,
                                          const std::string &calibration_type,
                                          bool &done);
@@ -108,7 +108,7 @@ TEST(HardwareTest, CalibrationGimbalAccelerometer)
     }
 }
 
-void receive_calibration_callback(const Calibration::Result &result,
+void receive_calibration_callback(const Calibration::Result result,
                                   const Calibration::ProgressData &progress_data,
                                   const std::string &calibration_type,
                                   bool &done)

--- a/integration_tests/calibration.cpp
+++ b/integration_tests/calibration.cpp
@@ -7,10 +7,9 @@
 using namespace dronecode_sdk;
 using namespace std::placeholders; // for `_1`
 
-static void receive_calibration_callback(Calibration::Result result,
-                                         float progress,
-                                         const std::string text,
-                                         const std::string calibration_type,
+static void receive_calibration_callback(const Calibration::Result &result,
+                                         const Calibration::ProgressData &progress_data,
+                                         const std::string &calibration_type,
                                          bool &done);
 
 TEST(HardwareTest, CalibrationGyro)
@@ -30,7 +29,7 @@ TEST(HardwareTest, CalibrationGyro)
     bool done = false;
 
     calibration->calibrate_gyro_async(
-        std::bind(&receive_calibration_callback, _1, _2, _3, "gyro", std::ref(done)));
+        std::bind(&receive_calibration_callback, _1, _2, "gyro", std::ref(done)));
 
     while (!done) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -54,7 +53,7 @@ TEST(HardwareTest, CalibrationAccelerometer)
     bool done = false;
 
     calibration->calibrate_accelerometer_async(
-        std::bind(&receive_calibration_callback, _1, _2, _3, "accelerometer", std::ref(done)));
+        std::bind(&receive_calibration_callback, _1, _2, "accelerometer", std::ref(done)));
 
     while (!done) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -78,7 +77,7 @@ TEST(HardwareTest, CalibrationMagnetometer)
     bool done = false;
 
     calibration->calibrate_magnetometer_async(
-        std::bind(&receive_calibration_callback, _1, _2, _3, "magnetometer", std::ref(done)));
+        std::bind(&receive_calibration_callback, _1, _2, "magnetometer", std::ref(done)));
 
     while (!done) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -101,24 +100,23 @@ TEST(HardwareTest, CalibrationGimbalAccelerometer)
 
     bool done = false;
 
-    calibration->calibrate_gimbal_accelerometer_async(std::bind(
-        &receive_calibration_callback, _1, _2, _3, "gimbal accelerometer", std::ref(done)));
+    calibration->calibrate_gimbal_accelerometer_async(
+        std::bind(&receive_calibration_callback, _1, _2, "gimbal accelerometer", std::ref(done)));
 
     while (!done) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 }
 
-void receive_calibration_callback(Calibration::Result result,
-                                  float progress,
-                                  const std::string text,
-                                  const std::string calibration_type,
+void receive_calibration_callback(const Calibration::Result &result,
+                                  const Calibration::ProgressData &progress_data,
+                                  const std::string &calibration_type,
                                   bool &done)
 {
     if (result == Calibration::Result::IN_PROGRESS) {
-        LogInfo() << calibration_type << " calibration in progress: " << progress;
+        LogInfo() << calibration_type << " calibration in progress: " << progress_data.progress;
     } else if (result == Calibration::Result::INSTRUCTION) {
-        LogInfo() << calibration_type << " calibration instruction: " << text;
+        LogInfo() << calibration_type << " calibration instruction: " << progress_data.status_text;
     } else {
         EXPECT_EQ(result, Calibration::Result::SUCCESS);
 
@@ -126,7 +124,8 @@ void receive_calibration_callback(Calibration::Result result,
             LogErr() << calibration_type
                      << " calibration error: " << Calibration::result_str(result);
             if (result == Calibration::Result::FAILED) {
-                LogErr() << calibration_type << " cailbration failed: " << text;
+                LogErr() << calibration_type
+                         << " cailbration failed: " << progress_data.status_text;
             }
         }
         done = true;

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -10,15 +10,15 @@ else()
 endif()
 
 add_subdirectory(action)
+add_subdirectory(calibration)
+add_subdirectory(camera)
+add_subdirectory(follow_me)
 add_subdirectory(gimbal)
+add_subdirectory(info)
+add_subdirectory(log_files)
+#add_subdirectory(logging) # Not implemented completely
 add_subdirectory(mission)
 add_subdirectory(offboard)
 add_subdirectory(telemetry)
-#add_subdirectory(logging) # Not implemented completely
-add_subdirectory(log_files)
-add_subdirectory(info)
-add_subdirectory(follow_me)
-add_subdirectory(camera)
-add_subdirectory(calibration)
 
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/plugins/calibration/calibration_impl.h
+++ b/plugins/calibration/calibration_impl.h
@@ -29,6 +29,9 @@ public:
     bool is_magnetometer_calibration_ok() const;
 
 private:
+    void call_user_callback(const Calibration::calibration_callback_t &callback,
+                            const Calibration::Result &result,
+                            const Calibration::ProgressData &progress_data);
     void process_statustext(const mavlink_message_t &message);
 
     void command_result_callback(MAVLinkCommands::Result command_result, float progress);

--- a/plugins/calibration/include/plugins/calibration/calibration.h
+++ b/plugins/calibration/include/plugins/calibration/calibration.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <functional>
+#include <string>
+
 #include "plugin_base.h"
 
 namespace dronecode_sdk {
@@ -33,7 +35,7 @@ public:
     ~Calibration();
 
     /**
-     * @brief Possible results returned for camera commands.
+     * @brief Possible results returned for calibration commands.
      */
     enum class Result {
         UNKNOWN,
@@ -50,6 +52,36 @@ public:
     };
 
     /**
+     * @brief Progress data coming from calibration.
+     *
+     * Can be a progress percentage, or an instruction text.
+     */
+    struct ProgressData {
+        bool has_progress; ///< Whether or not this struct contains progress information.
+        float progress; ///< The actual progress.
+        bool has_status_text; ///< Whether or not this struct contains an instruction text.
+        std::string status_text; ///< The actual instruction text.
+
+        /**
+         * Constructor for ProgressData.
+         *
+         * @param _has_progress Whether or not this struct contains progress information.
+         * @param _progress The actual progress.
+         * @param _has_status_text Whether or not this struct contains an instruction text.
+         * @param _status_text The actual instruction text.
+         */
+        ProgressData(const bool _has_progress,
+                     const float _progress,
+                     const bool _has_status_text,
+                     const std::string &_status_text) :
+            has_progress(_has_progress),
+            progress(_progress),
+            has_status_text(_has_status_text),
+            status_text(_status_text)
+        {}
+    };
+
+    /**
      * @brief Returns a human-readable English string for Calibration::Result.
      *
      * @param result The enum value for which a human readable string is required.
@@ -60,8 +92,7 @@ public:
     /**
      * @brief Callback type for asynchronous calibration call.
      */
-    typedef std::function<void(Result result, float progress, const std::string &text)>
-        calibration_callback_t;
+    typedef std::function<void(const Result result, const ProgressData)> calibration_callback_t;
 
     /**
      * @brief Perform gyro calibration (asynchronous call).


### PR DESCRIPTION
Because of the Rx language bindings, we cannot have more than one return type (that is, one `Result` that says when there is an error and when the stream completes, and one actual struct containing data). This has to be reflected in the C++ API if we want to auto-generate those headers, too.

Moreover, some languages don't have the notion of `NaN` and default to `0` (which is an issue for e.g. a `progress`). For this reason, the resulting struct has booleans to explicitly say if a value is defined or not.

Finally, I tried to remove some code duplication (see [here](https://github.com/Dronecode/DronecodeSDK/compare/calibration-callback-one-result?expand=1#diff-e2a195cc797105ca574a291666fd69ebR77)). It should behave the same in my understanding.