### PR TITLE
core: fix baudrate on Linux

### DIFF
--- a/core/serial_connection.cpp
+++ b/core/serial_connection.cpp
@@ -150,6 +150,9 @@ ConnectionResult SerialConnection::setup_port()
     tc.c_cflag &= ~(CBAUD);
     tc.c_cflag |= BOTHER;
 
+    tc.c_ispeed = _baudrate;
+    tc.c_ospeed = _baudrate;
+
     if (ioctl(_fd, TCSETS2, &tc) == -1) {
         LogErr() << "Could not set terminal attributes " << GET_ERROR();
         close(_fd);


### PR DESCRIPTION
This fixes a bug introduced in #372.

By adding macOS support for serial, I had accidentally removed setting the baudrate for Linux.

Fixes #563.