### PR TITLE
external_example: fix paths

### DIFF
--- a/external_example/integration_tests/CMakeLists.txt
+++ b/external_example/integration_tests/CMakeLists.txt
@@ -1,16 +1,15 @@
 cmake_minimum_required(VERSION 3.1)
 
 add_executable(external_example_integration_tests_runner
-    ../../core/unittests_main.cpp
+    ${CMAKE_SOURCE_DIR}/core/unittests_main.cpp
     hello_world.cpp
 )
 
 include_directories(
-    ../../core
-    ../../integration_tests
-    ../../external_example
-    ../../third_party/gtest/googletest/include
-    ../../third_party/gtest/googlemock/include
+    ${CMAKE_SOURCE_DIR}/core
+    ${CMAKE_SOURCE_DIR}/integration_tests
+    ${CMAKE_SOURCE_DIR}/third_party/gtest/googletest/include
+    ${CMAKE_SOURCE_DIR}/third_party/gtest/googlemock/include
 )
 
 target_link_libraries(external_example_integration_tests_runner


### PR DESCRIPTION
This fixes the paths for me in a try according to:
https://sdk.dronecode.org/en/guide/sdk_extensions.html