### PR TITLE
[wip] git: contributor and organization map

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+# PX4 .mailmap
+# See this guide for help modifying this file https://github.com/sympy/sympy/wiki/Using-.mailmap
+# Please append your entry
+# Example use of this map:
+#   git log --pretty='%aN <%aE>' | sort | uniq -c | sort -rn
+
+Julian Oes <julian@oes.ch>
+Julian Oes <julian@oes.ch> Julian Oes <joes@student.ethz.ch>
+Jonas Vautherin <jonas.vautherin@gmail.com>
+Jonas Vautherin <jonas.vautherin@gmail.com> Jones <jones@jones-vostok.home>
+Prashanth Shakthi <shakthi.prashanth.m@intel.com>
+Prashanth Shakthi <shakthi.prashanth.m@intel.com> Shakthi Prashanth M <shakthi.prashanth.m@intel.com>
+Hamish Willee <hamishwillee@gmail.com>
+Ritul Jasuja <ritul.jasuja@intel.com> ritul jasuja <ritul.jasuja@intel.com>
+Dennis Mannhart <dennis@yuneecresearch.com> Dennis Mannhart <dennis.mannhart@gmail.com>
+Dennis Mannhart <dennis@yuneecresearch.com> Dennis Mannhart <dennis@px4.io>
+Beat Küng <beat-kueng@gmx.net> <beat-kueng@gmx.net>
+Ramón Roche <mrpollo@gmail.com>
+Avinash Reddy Palleti <avinash.reddy.palleti@intel.com> avinash-palleti <avinash.reddy.palleti@intel.com>
+Martina Rivizzigno <martina@rivizzigno.it>
+Dario Röthlisberger <dario.roethlisberger@gmail.com>
+Thomas Etter <thomas.etter@auterion.com>
+Simone Guscetti <simone@yuneecresearch.com>
+Simone Guscetti <simone@yuneecresearch.com> Simone Guscetti <simone@px4.io>
+Matthias Grob <maetugr@gmail.com>
+Lalit Kumar <lalit.kumar.begani@intel.com>
+David Sidrane <david_s5@nscdg.com>
+Anthony Lamping <lamping.ap@gmail.com> <lamping.ap@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -1,0 +1,55 @@
+#
+# More information at
+#  http://tracker.ceph.com/projects/ceph/wiki/Ceph_contributors_list_maintenance_guide
+#
+# See .githubmap for GitHub username contributors
+# See .mailmap for name and mail normalization.
+# See .peoplemap for unique list of people
+#
+# To display the 10 organization who contributed
+# most commits to ceph ( requires git >= 1.8.4 ):
+#
+# git log --pretty='%aN <%aE>' | git -c mailmap.file=.organizationmap check-mailmap --stdin | sort | uniq -c | sort -rn
+#   1333 Yuneec Research <contact@yuneecresearch.com>
+#    271 Auterion <contact@auterion.com>
+#    203 Intel <contact@intel.com>
+#     19 Yuneec <contact@yuneec.com>
+#      6 Mohamed Abdelkader Zahana <mohamedashraf123@gmail.com>
+#      5 Dronecode <contact@dronecode.com>
+#      3 Independent <no@organization.net>
+#      2 Yuneec USA <contact@usa.yuneec.com>
+#      1 xgerrmann <xander@gerrmann.nl>
+#      1 Simone Guscetti <simone@px4.io>
+#      1 Gabriel Moreno <gabrielm@cs.cmu.edu>
+#      1 Fabian Klabacher <fklabach@gmail.com>
+#      1 Bert <b.buchholz@kitepower.nl>
+
+Auterion <contact@auterion.com> Beat Küng <beat-kueng@gmx.net>
+Auterion <contact@auterion.com> Barza Nisar <nisarb@student.ethz.ch>
+Auterion <contact@auterion.com> Gus Grubba <mavlink@grubba.com>
+Auterion <contact@auterion.com> Jonas Vautherin <jonas.vautherin@gmail.com>
+Auterion <contact@auterion.com> Thomas Etter <thomas.etter@auterion.com>
+Auterion <contact@auterion.com> Hamish Willee <hamishwillee@gmail.com>
+Dronecode <contact@dronecode.com> Ramón Roche <mrpollo@gmail.com>
+Intel <contact@intel.com> Avinash Reddy Palleti <avinash.reddy.palleti@intel.com>
+Intel <contact@intel.com> Ritul Jasuja <ritul.jasuja@intel.com>
+Intel <contact@intel.com> Prashanth Shakthi <shakthi.prashanth.m@intel.com>
+Intel <contact@intel.com> Lalit Kumar <lalit.kumar.begani@intel.com>
+Independent <no@organization.net> Daniel Agar <daniel@agar.ca>
+Independent <no@organization.net> David Sidrane <david_s5@nscdg.com>
+Independent <no@organization.net> Anthony Lamping <lamping.ap@gmail.com>
+Yuneec Research <contact@yuneecresearch.com> Julian Oes <julian@oes.ch>
+Yuneec Research <contact@yuneecresearch.com> Dario Röthlisberger <dario.roethlisberger@gmail.com>
+Yuneec Research <contact@yuneecresearch.com> Dennis Mannhart <dennis@yuneecresearch.com>
+Yuneec Research <contact@yuneecresearch.com> Simone Guscetti <simone@yuneecresearch.com>
+Yuneec Research <contact@yuneecresearch.com> Martina Rivizzigno <martina@rivizzigno.it>
+Yuneec Research <contact@yuneecresearch.com> Matthias Grob <maetugr@gmail.com>
+Yuneec <contact@yuneec.com> Dave Bowerman <david.bowerman@gmail.com>
+Yuneec USA <contact@usa.yuneec.com> Sushma Sathyanarayana <sush.satyan@gmail.com>
+
+#
+# Local Variables:
+# compile-command: "git log --pretty='%aN <%aE>' | \
+#   git -c mailmap.file=.organizationmap check-mailmap --stdin | \
+#   sort | uniq -c | sort -rn | nl"
+# End:


### PR DESCRIPTION
initial dump from PX4/QGC mailmap/orgmap, there's a simple way to test this (using one year as data sample)

Contributor list (clean)
```
git log --pretty='%aN <%aE>' --since="1 year" | sort | uniq -c | sort -rn

 739 Julian Oes <julian@oes.ch>
 202 Jonas Vautherin <jonas.vautherin@gmail.com>
 177 Prashanth Shakthi <shakthi.prashanth.m@intel.com>
  28 Hamish Willee <hamishwillee@gmail.com>
  19 Dave Bowerman <david.bowerman@gmail.com>
  12 Ritul Jasuja <ritul.jasuja@intel.com>
  11 Dennis Mannhart <dennis@yuneecresearch.com>
   7 Beat Küng <beat-kueng@gmx.net>
   6 Mohamed Abdelkader Zahana <mohamedashraf123@gmail.com>
   2 Sushma Sathyanarayana <sush.satyan@gmail.com>
   1 xgerrmann <xander@gerrmann.nl>
   1 Thomas Etter <thomas.etter@auterion.com>
   1 Ramón Roche <mrpollo@gmail.com>
   1 Matthias Grob <maetugr@gmail.com>
   1 Lalit Kumar <lalit.kumar.begani@intel.com>
   1 Gabriel Moreno <gabrielm@cs.cmu.edu>
   1 Fabian Klabacher <fklabach@gmail.com>
   1 Daniel Agar <daniel@agar.ca>
   1 Bert <b.buchholz@kitepower.nl>
   1 Avinash Reddy Palleti <avinash.reddy.palleti@intel.com>
   1 Anthony Lamping <lamping.ap@gmail.com>
```

Organization list
```
git log --pretty='%aN <%aE>' --since="1 year" | git -c mailmap.file=.organizationmap check-mailmap --stdin | sort | uniq -c | sort -rn

 751 Yuneec Research <contact@yuneecresearch.com>
 238 Auterion <contact@auterion.com>
 191 Intel <contact@intel.com>
  19 Yuneec <contact@yuneec.com>
   6 Mohamed Abdelkader Zahana <mohamedashraf123@gmail.com>
   2 Yuneec USA <contact@usa.yuneec.com>
   2 Unaffiliated <no@organization.net>
   1 xgerrmann <xander@gerrmann.nl>
   1 Gabriel Moreno <gabrielm@cs.cmu.edu>
   1 Fabian Klabacher <fklabach@gmail.com>
   1 Dronecode <contact@dronecode.com>
   1 Bert <b.buchholz@kitepower.nl>
```