### PR TITLE
camera: propagate camera status fixes to other streams in camera service

### DIFF
--- a/backend/src/plugins/camera/camera_service_impl.h
+++ b/backend/src/plugins/camera/camera_service_impl.h
@@ -169,16 +169,17 @@ public:
         std::promise<void> stream_closed_promise;
         auto stream_closed_future = stream_closed_promise.get_future();
 
-        bool is_finished = false;
+        auto is_finished = std::make_shared<bool>(false);
 
-        _camera.subscribe_mode([this, &writer, &stream_closed_promise, &is_finished](
+        _camera.subscribe_mode([this, &writer, &stream_closed_promise, is_finished](
                                    const dronecode_sdk::Camera::Mode mode) {
             rpc::camera::ModeResponse rpc_mode_response;
             rpc_mode_response.set_camera_mode(translateCameraMode(mode));
 
             std::lock_guard<std::mutex> lock(_subscribe_mutex);
-            if (!writer->Write(rpc_mode_response) && !is_finished) {
-                is_finished = true;
+            if (!*is_finished && !writer->Write(rpc_mode_response)) {
+                _camera.subscribe_status(nullptr);
+                *is_finished = true;
                 stream_closed_promise.set_value();
             }
         });
@@ -294,10 +295,10 @@ public:
         std::promise<void> stream_closed_promise;
         auto stream_closed_future = stream_closed_promise.get_future();
 
-        bool is_finished = false;
+        auto is_finished = std::make_shared<bool>(false);
 
         _camera.subscribe_video_stream_info(
-            [this, &writer, &stream_closed_promise, &is_finished](
+            [this, &writer, &stream_closed_promise, is_finished](
                 const dronecode_sdk::Camera::VideoStreamInfo video_info) {
                 rpc::camera::VideoStreamInfoResponse rpc_video_stream_info_response;
                 auto video_stream_info = translateVideoStreamInfo(video_info);
@@ -305,8 +306,9 @@ public:
                     video_stream_info.release());
 
                 std::lock_guard<std::mutex> lock(_subscribe_mutex);
-                if (!writer->Write(rpc_video_stream_info_response) && !is_finished) {
-                    is_finished = true;
+                if (!*is_finished && !writer->Write(rpc_video_stream_info_response)) {
+                    _camera.subscribe_status(nullptr);
+                    *is_finished = true;
                     stream_closed_promise.set_value();
                 }
             });
@@ -324,17 +326,18 @@ public:
         std::promise<void> stream_closed_promise;
         auto stream_closed_future = stream_closed_promise.get_future();
 
-        bool is_finished = false;
+        auto is_finished = std::make_shared<bool>(false);
 
-        _camera.subscribe_capture_info([this, &writer, &stream_closed_promise, &is_finished](
+        _camera.subscribe_capture_info([this, &writer, &stream_closed_promise, is_finished](
                                            const dronecode_sdk::Camera::CaptureInfo capture_info) {
             rpc::camera::CaptureInfoResponse rpc_capture_info_response;
             auto rpc_capture_info = translateCaptureInfo(capture_info);
             rpc_capture_info_response.set_allocated_capture_info(rpc_capture_info.release());
 
             std::lock_guard<std::mutex> lock(_subscribe_mutex);
-            if (!writer->Write(rpc_capture_info_response) && !is_finished) {
-                is_finished = true;
+            if (!*is_finished && !writer->Write(rpc_capture_info_response)) {
+                _camera.subscribe_status(nullptr);
+                *is_finished = true;
                 stream_closed_promise.set_value();
             }
         });
@@ -549,10 +552,10 @@ public:
         std::promise<void> stream_closed_promise;
         auto stream_closed_future = stream_closed_promise.get_future();
 
-        bool is_finished = false;
+        auto is_finished = std::make_shared<bool>(false);
 
         _camera.subscribe_current_settings(
-            [this, &writer, &stream_closed_promise, &is_finished](
+            [this, &writer, &stream_closed_promise, is_finished](
                 const std::vector<dronecode_sdk::Camera::Setting> current_settings) {
                 rpc::camera::CurrentSettingsResponse rpc_current_setting_response;
 
@@ -562,8 +565,9 @@ public:
                 }
 
                 std::lock_guard<std::mutex> lock(_subscribe_mutex);
-                if (!writer->Write(rpc_current_setting_response) && !is_finished) {
-                    is_finished = true;
+                if (!*is_finished && !writer->Write(rpc_current_setting_response)) {
+                    _camera.subscribe_status(nullptr);
+                    *is_finished = true;
                     stream_closed_promise.set_value();
                 }
             });
@@ -619,10 +623,10 @@ public:
         std::promise<void> stream_closed_promise;
         auto stream_closed_future = stream_closed_promise.get_future();
 
-        bool is_finished = false;
+        auto is_finished = std::make_shared<bool>(false);
 
         _camera.subscribe_possible_setting_options(
-            [this, &writer, &stream_closed_promise, &is_finished](
+            [this, &writer, &stream_closed_promise, is_finished](
                 const std::vector<dronecode_sdk::Camera::SettingOptions> setting_options) {
                 rpc::camera::PossibleSettingOptionsResponse rpc_setting_options_response;
 
@@ -632,8 +636,9 @@ public:
                 }
 
                 std::lock_guard<std::mutex> lock(_subscribe_mutex);
-                if (!writer->Write(rpc_setting_options_response) && !is_finished) {
-                    is_finished = true;
+                if (!*is_finished && !writer->Write(rpc_setting_options_response)) {
+                    _camera.subscribe_status(nullptr);
+                    *is_finished = true;
                     stream_closed_promise.set_value();
                 }
             });

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -782,10 +782,15 @@ CameraImpl::to_euler_angle_from_quaternion(Camera::CaptureInfo::Quaternion quate
 
 void CameraImpl::notify_capture_info(Camera::CaptureInfo capture_info)
 {
-    if (_capture_info.callback) {
-        _parent->call_user_callback(
-            [this, capture_info]() { _capture_info.callback(capture_info); });
+    // Make a copy because it is passed to the thread pool
+    const auto capture_info_callback = _capture_info.callback;
+
+    if (capture_info_callback == nullptr) {
+        return;
     }
+
+    _parent->call_user_callback(
+        [capture_info, capture_info_callback]() { capture_info_callback(capture_info); });
 }
 
 void CameraImpl::process_camera_settings(const mavlink_message_t &message)
@@ -1035,9 +1040,14 @@ void CameraImpl::receive_set_mode_command_result(const MAVLinkCommands::Result c
 
 void CameraImpl::notify_mode(const Camera::Mode mode)
 {
-    if (_subscribe_mode_callback) {
-        _parent->call_user_callback([this, mode]() { _subscribe_mode_callback(mode); });
+    // Make a copy because it is passed to the thread pool
+    const auto mode_callback = _subscribe_mode_callback;
+
+    if (mode_callback == nullptr) {
+        return;
     }
+
+    _parent->call_user_callback([mode, mode_callback]() { mode_callback(mode); });
 }
 
 void CameraImpl::receive_get_mode_command_result(MAVLinkCommands::Result command_result)


### PR DESCRIPTION
Note: That PR is targetting the camera status PR, and not develop.