### PR TITLE
Add plugin to set params

### DIFF
--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -58,10 +58,10 @@ void MAVLinkParameters::set_param_async(const std::string &name,
 MAVLinkParameters::Result
 MAVLinkParameters::set_param(const std::string &name, const ParamValue &value, bool extended)
 {
-    auto prom = std::make_shared<std::promise<Result>>();
-    auto res = prom->get_future();
+    auto prom = std::promise<Result>();
+    auto res = prom.get_future();
 
-    set_param_async(name, value, [&prom](Result result) { prom->set_value(result); }, extended);
+    set_param_async(name, value, [&prom](Result result) { prom.set_value(result); }, extended);
 
     return res.get();
 }
@@ -103,13 +103,13 @@ void MAVLinkParameters::get_param_async(const std::string &name,
 std::pair<MAVLinkParameters::Result, MAVLinkParameters::ParamValue>
 MAVLinkParameters::get_param(const std::string &name, ParamValue value_type, bool extended)
 {
-    auto prom = std::make_shared<std::promise<std::pair<Result, MAVLinkParameters::ParamValue>>>();
-    auto res = prom->get_future();
+    auto prom = std::promise<std::pair<Result, MAVLinkParameters::ParamValue>>();
+    auto res = prom.get_future();
 
     get_param_async(name,
                     value_type,
                     [&prom](Result result, ParamValue value) {
-                        prom->set_value(std::make_pair<>(result, value));
+                        prom.set_value(std::make_pair<>(result, value));
                     },
                     extended);
 

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -38,7 +38,7 @@ void MAVLinkParameters::set_param_async(const std::string &name,
     //     LogDebug() << "setting param " << name << " to " << value.get_int();
     // }
 
-    if (name.size() > PARAM_ID_LEN) {
+    if (name.size() >= PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
             callback(false);
@@ -72,7 +72,7 @@ void MAVLinkParameters::get_param_async(const std::string &name,
 {
     // LogDebug() << "getting param " << name << ", extended: " << (extended ? "yes" : "no");
 
-    if (name.size() > PARAM_ID_LEN) {
+    if (name.size() >= PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
             ParamValue empty_param;

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -38,7 +38,7 @@ void MAVLinkParameters::set_param_async(const std::string &name,
     //     LogDebug() << "setting param " << name << " to " << value.get_int();
     // }
 
-    if (name.size() >= PARAM_ID_LEN) {
+    if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
             callback(Result::PARAM_NAME_TOO_LONG);
@@ -73,7 +73,7 @@ void MAVLinkParameters::get_param_async(const std::string &name,
 {
     // LogDebug() << "getting param " << name << ", extended: " << (extended ? "yes" : "no");
 
-    if (name.size() >= PARAM_ID_LEN) {
+    if (name.size() > PARAM_ID_LEN) {
         LogErr() << "Error: param name too long";
         if (callback) {
             ParamValue empty_param;
@@ -140,7 +140,7 @@ void MAVLinkParameters::do_work()
         // We need to wait for this param to get sent back as confirmation.
         _state = State::SET_PARAM_BUSY;
 
-        char param_id[PARAM_ID_LEN] = {};
+        char param_id[PARAM_ID_LEN + 1] = {};
         STRNCPY(param_id, set_param_work->param_name.c_str(), sizeof(param_id) - 1);
 
         mavlink_message_t message = {};
@@ -194,7 +194,7 @@ void MAVLinkParameters::do_work()
         // or after a timeout.
         _state = State::GET_PARAM_BUSY;
 
-        char param_id[PARAM_ID_LEN] = {};
+        char param_id[PARAM_ID_LEN + 1] = {};
         STRNCPY(param_id, get_param_work->param_name.c_str(), sizeof(param_id) - 1);
 
         // LogDebug() << "now getting: " << get_param_work->param_name;

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -470,18 +470,20 @@ public:
         Any _value;
     };
 
-    typedef std::function<void(bool success)> set_param_callback_t;
+    enum class Result { SUCCESS, TIMEOUT, CONNECTION_ERROR, WRONG_TYPE, PARAM_NAME_TOO_LONG };
 
-    bool set_param(const std::string &name, const ParamValue &value, bool extended = false);
+    typedef std::function<void(Result result)> set_param_callback_t;
+
+    Result set_param(const std::string &name, const ParamValue &value, bool extended = false);
 
     void set_param_async(const std::string &name,
                          const ParamValue &value,
                          set_param_callback_t callback,
                          bool extended = false);
 
-    std::pair<bool, ParamValue>
+    std::pair<Result, ParamValue>
     get_param(const std::string &name, ParamValue value_type, bool extended);
-    typedef std::function<void(bool success, ParamValue value)> get_param_callback_t;
+    typedef std::function<void(Result, ParamValue value)> get_param_callback_t;
     void get_param_async(const std::string &name,
                          ParamValue value_type,
                          get_param_callback_t callback,

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -119,7 +119,7 @@ public:
             }
         }
 
-        void set_from_xml(const std::string &type_str, const std::string &value_str)
+        bool set_from_xml(const std::string &type_str, const std::string &value_str)
         {
             if (strcmp(type_str.c_str(), "uint8") == 0) {
                 uint8_t temp = std::stoi(value_str.c_str());
@@ -153,7 +153,38 @@ public:
                 _value = temp;
             } else {
                 LogErr() << "Unknown type: " << type_str;
+                return false;
             }
+            return true;
+        }
+
+        bool set_empty_type_from_xml(const std::string &type_str)
+        {
+            if (strcmp(type_str.c_str(), "uint8") == 0) {
+                _value = uint8_t(0);
+            } else if (strcmp(type_str.c_str(), "int8") == 0) {
+                _value = int8_t(0);
+            } else if (strcmp(type_str.c_str(), "uint16") == 0) {
+                _value = uint16_t(0);
+            } else if (strcmp(type_str.c_str(), "int16") == 0) {
+                _value = int16_t(0);
+            } else if (strcmp(type_str.c_str(), "uint32") == 0) {
+                _value = uint32_t(0);
+            } else if (strcmp(type_str.c_str(), "int32") == 0) {
+                _value = int32_t(0);
+            } else if (strcmp(type_str.c_str(), "uint64") == 0) {
+                _value = uint64_t(0);
+            } else if (strcmp(type_str.c_str(), "uint64") == 0) {
+                _value = int64_t(0);
+            } else if (strcmp(type_str.c_str(), "float") == 0) {
+                _value = 0.0f;
+            } else if (strcmp(type_str.c_str(), "double") == 0) {
+                _value = 0.0;
+            } else {
+                LogErr() << "Unknown type: " << type_str;
+                return false;
+            }
+            return true;
         }
 
         MAV_PARAM_TYPE get_mav_param_type() const
@@ -163,6 +194,7 @@ public:
             } else if (_value.is<int32_t>()) {
                 return MAV_PARAM_TYPE_INT32;
             } else {
+                LogErr() << "Unknown param type sent";
                 return MAV_PARAM_TYPE_REAL32;
             }
         }
@@ -343,6 +375,7 @@ public:
         bool operator==(const ParamValue &rhs) const
         {
             if (!is_same_type(rhs)) {
+                LogWarn() << "Trying to compare different types.";
                 return false;
             }
             if (_value.is<uint8_t>()) {
@@ -366,11 +399,12 @@ public:
             } else if (_value.is<double>()) {
                 return _value.as<double>() == rhs._value.as<double>();
             } else if (_value.is<custom_type_t>()) {
-                // FIXME: not clear how to handle this
+                LogErr() << "Comparing custom_type not supported.";
+                return false;
+            } else {
+                LogErr() << "Comparing unknown types";
                 return false;
             }
-            // FIXME: Added to fix CI error (control reading end of non-void function)
-            return false;
         }
 
         bool operator==(const std::string &value_str) const
@@ -445,10 +479,13 @@ public:
                          set_param_callback_t callback,
                          bool extended = false);
 
-    std::pair<bool, ParamValue> get_param(const std::string &name, bool extended);
+    std::pair<bool, ParamValue>
+    get_param(const std::string &name, ParamValue value_type, bool extended);
     typedef std::function<void(bool success, ParamValue value)> get_param_callback_t;
-    void
-    get_param_async(const std::string &name, get_param_callback_t callback, bool extended = false);
+    void get_param_async(const std::string &name,
+                         ParamValue value_type,
+                         get_param_callback_t callback,
+                         bool extended = false);
 
     void do_work();
 
@@ -488,6 +525,7 @@ private:
     struct GetParamWork {
         get_param_callback_t callback = nullptr;
         std::string param_name{};
+        ParamValue param_value_type{};
         bool extended = false;
         int retries_done = 0;
     };

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -510,9 +510,8 @@ private:
     enum class State { NONE, SET_PARAM_BUSY, GET_PARAM_BUSY } _state = State::NONE;
     std::mutex _state_mutex{};
 
-    // Params can be up to 16 chars and without 0-termination.
-    // Therefore we add a 0 here for storing.
-    static constexpr size_t PARAM_ID_LEN = 16 + 1;
+    // Params can be up to 16 chars without 0-termination.
+    static constexpr size_t PARAM_ID_LEN = 16;
 
     struct SetParamWork {
         set_param_callback_t callback = nullptr;

--- a/core/system_impl.cpp
+++ b/core/system_impl.cpp
@@ -633,8 +633,8 @@ void SystemImpl::set_param_ext_int_async(const std::string &name, int32_t value,
 
 std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(const std::string &name)
 {
-    auto prom = std::make_shared<std::promise<std::pair<MAVLinkParameters::Result, float>>>();
-    auto res = prom->get_future();
+    auto prom = std::promise<std::pair<MAVLinkParameters::Result, float>>();
+    auto res = prom.get_future();
 
     MAVLinkParameters::ParamValue value_type;
     value_type.set_float(0.0f);
@@ -647,7 +647,7 @@ std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(const st
             if (result == MAVLinkParameters::Result::SUCCESS) {
                 value = param.get_float();
             }
-            prom->set_value(std::make_pair<>(result, value));
+            prom.set_value(std::make_pair<>(result, value));
         });
 
     return res.get();
@@ -655,8 +655,8 @@ std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(const st
 
 std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::string &name)
 {
-    auto prom = std::make_shared<std::promise<std::pair<MAVLinkParameters::Result, int>>>();
-    auto res = prom->get_future();
+    auto prom = std::promise<std::pair<MAVLinkParameters::Result, int>>();
+    auto res = prom.get_future();
 
     MAVLinkParameters::ParamValue value_type;
     value_type.set_int32(0);
@@ -669,7 +669,7 @@ std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::s
             if (result == MAVLinkParameters::Result::SUCCESS) {
                 value = param.get_int32();
             }
-            prom->set_value(std::make_pair<>(result, value));
+            prom.set_value(std::make_pair<>(result, value));
         });
 
     return res.get();
@@ -677,8 +677,8 @@ std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::s
 
 std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_ext_float(const std::string &name)
 {
-    auto prom = std::make_shared<std::promise<std::pair<MAVLinkParameters::Result, float>>>();
-    auto res = prom->get_future();
+    auto prom = std::promise<std::pair<MAVLinkParameters::Result, float>>();
+    auto res = prom.get_future();
 
     MAVLinkParameters::ParamValue value_type;
     value_type.set_float(0.0f);
@@ -691,7 +691,7 @@ std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_ext_float(cons
             if (result == MAVLinkParameters::Result::SUCCESS) {
                 value = param.get_float();
             }
-            prom->set_value(std::make_pair<>(result, value));
+            prom.set_value(std::make_pair<>(result, value));
         },
         true);
 
@@ -700,8 +700,8 @@ std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_ext_float(cons
 
 std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_ext_int(const std::string &name)
 {
-    auto prom = std::make_shared<std::promise<std::pair<MAVLinkParameters::Result, int>>>();
-    auto res = prom->get_future();
+    auto prom = std::promise<std::pair<MAVLinkParameters::Result, int>>();
+    auto res = prom.get_future();
 
     MAVLinkParameters::ParamValue value_type;
     value_type.set_int32(0);
@@ -714,7 +714,7 @@ std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_ext_int(const st
             if (result == MAVLinkParameters::Result::SUCCESS) {
                 value = param.get_int32();
             }
-            prom->set_value(std::make_pair<>(result, value));
+            prom.set_value(std::make_pair<>(result, value));
         },
         true);
 

--- a/core/system_impl.cpp
+++ b/core/system_impl.cpp
@@ -636,13 +636,17 @@ std::pair<bool, float> SystemImpl::get_param_float(const std::string &name)
     auto prom = std::make_shared<std::promise<std::pair<bool, float>>>();
     auto res = prom->get_future();
 
-    _params.get_param_async(name, [&prom](bool success, MAVLinkParameters::ParamValue param) {
-        float value = NAN;
-        if (success) {
-            value = param.get_float();
-        }
-        prom->set_value(std::make_pair<>(success, value));
-    });
+    MAVLinkParameters::ParamValue value_type;
+    value_type.set_float(0.0f);
+
+    _params.get_param_async(
+        name, value_type, [&prom](bool success, MAVLinkParameters::ParamValue param) {
+            float value = NAN;
+            if (success) {
+                value = param.get_float();
+            }
+            prom->set_value(std::make_pair<>(success, value));
+        });
 
     return res.get();
 }
@@ -652,13 +656,17 @@ std::pair<bool, int> SystemImpl::get_param_int(const std::string &name)
     auto prom = std::make_shared<std::promise<std::pair<bool, int>>>();
     auto res = prom->get_future();
 
-    _params.get_param_async(name, [&prom](bool success, MAVLinkParameters::ParamValue param) {
-        int value = 0;
-        if (success) {
-            value = param.get_int32();
-        }
-        prom->set_value(std::make_pair<>(success, value));
-    });
+    MAVLinkParameters::ParamValue value_type;
+    value_type.set_int32(0);
+
+    _params.get_param_async(
+        name, value_type, [&prom](bool success, MAVLinkParameters::ParamValue param) {
+            int value = 0;
+            if (success) {
+                value = param.get_int32();
+            }
+            prom->set_value(std::make_pair<>(success, value));
+        });
 
     return res.get();
 }
@@ -668,7 +676,11 @@ std::pair<bool, float> SystemImpl::get_param_ext_float(const std::string &name)
     auto prom = std::make_shared<std::promise<std::pair<bool, float>>>();
     auto res = prom->get_future();
 
+    MAVLinkParameters::ParamValue value_type;
+    value_type.set_float(0.0f);
+
     _params.get_param_async(name,
+                            value_type,
                             [&prom](bool success, MAVLinkParameters::ParamValue param) {
                                 float value = NAN;
                                 if (success) {
@@ -686,7 +698,11 @@ std::pair<bool, int> SystemImpl::get_param_ext_int(const std::string &name)
     auto prom = std::make_shared<std::promise<std::pair<bool, int>>>();
     auto res = prom->get_future();
 
+    MAVLinkParameters::ParamValue value_type;
+    value_type.set_int32(0.0f);
+
     _params.get_param_async(name,
+                            value_type,
                             [&prom](bool success, MAVLinkParameters::ParamValue param) {
                                 int value = 0;
                                 if (success) {
@@ -701,25 +717,39 @@ std::pair<bool, int> SystemImpl::get_param_ext_int(const std::string &name)
 
 void SystemImpl::get_param_float_async(const std::string &name, get_param_float_callback_t callback)
 {
-    _params.get_param_async(name, std::bind(&SystemImpl::receive_float_param, _1, _2, callback));
+    MAVLinkParameters::ParamValue value_type;
+    value_type.set_float(0.0f);
+
+    _params.get_param_async(
+        name, value_type, std::bind(&SystemImpl::receive_float_param, _1, _2, callback));
 }
 
 void SystemImpl::get_param_int_async(const std::string &name, get_param_int_callback_t callback)
 {
-    _params.get_param_async(name, std::bind(&SystemImpl::receive_int_param, _1, _2, callback));
+    MAVLinkParameters::ParamValue value_type;
+    value_type.set_int32(0.0f);
+
+    _params.get_param_async(
+        name, value_type, std::bind(&SystemImpl::receive_int_param, _1, _2, callback));
 }
 
 void SystemImpl::get_param_ext_float_async(const std::string &name,
                                            get_param_float_callback_t callback)
 {
+    MAVLinkParameters::ParamValue value_type;
+    value_type.set_float(0.0f);
+
     _params.get_param_async(
-        name, std::bind(&SystemImpl::receive_float_param, _1, _2, callback), true);
+        name, value_type, std::bind(&SystemImpl::receive_float_param, _1, _2, callback), true);
 }
 
 void SystemImpl::get_param_ext_int_async(const std::string &name, get_param_int_callback_t callback)
 {
+    MAVLinkParameters::ParamValue value_type;
+    value_type.set_int32(0.0f);
+
     _params.get_param_async(
-        name, std::bind(&SystemImpl::receive_int_param, _1, _2, callback), true);
+        name, value_type, std::bind(&SystemImpl::receive_int_param, _1, _2, callback), true);
 }
 
 void SystemImpl::set_param_async(const std::string &name,
@@ -738,10 +768,11 @@ bool SystemImpl::set_param(const std::string &name,
 }
 
 void SystemImpl::get_param_async(const std::string &name,
+                                 MAVLinkParameters::ParamValue value_type,
                                  get_param_callback_t callback,
                                  bool extended)
 {
-    _params.get_param_async(name, callback, extended);
+    _params.get_param_async(name, value_type, callback, extended);
 }
 
 std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong>

--- a/core/system_impl.cpp
+++ b/core/system_impl.cpp
@@ -704,7 +704,7 @@ std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_ext_int(const st
     auto res = prom->get_future();
 
     MAVLinkParameters::ParamValue value_type;
-    value_type.set_int32(0.0f);
+    value_type.set_int32(0);
 
     _params.get_param_async(
         name,
@@ -733,7 +733,7 @@ void SystemImpl::get_param_float_async(const std::string &name, get_param_float_
 void SystemImpl::get_param_int_async(const std::string &name, get_param_int_callback_t callback)
 {
     MAVLinkParameters::ParamValue value_type;
-    value_type.set_int32(0.0f);
+    value_type.set_int32(0);
 
     _params.get_param_async(
         name, value_type, std::bind(&SystemImpl::receive_int_param, _1, _2, callback));
@@ -752,7 +752,7 @@ void SystemImpl::get_param_ext_float_async(const std::string &name,
 void SystemImpl::get_param_ext_int_async(const std::string &name, get_param_int_callback_t callback)
 {
     MAVLinkParameters::ParamValue value_type;
-    value_type.set_int32(0.0f);
+    value_type.set_int32(0);
 
     _params.get_param_async(
         name, value_type, std::bind(&SystemImpl::receive_int_param, _1, _2, callback), true);

--- a/core/system_impl.cpp
+++ b/core/system_impl.cpp
@@ -571,7 +571,7 @@ void SystemImpl::set_system_id(uint8_t system_id)
     _system_id = system_id;
 }
 
-bool SystemImpl::set_param_float(const std::string &name, float value)
+MAVLinkParameters::Result SystemImpl::set_param_float(const std::string &name, float value)
 {
     MAVLinkParameters::ParamValue param_value;
     param_value.set_float(value);
@@ -579,7 +579,7 @@ bool SystemImpl::set_param_float(const std::string &name, float value)
     return _params.set_param(name, param_value, false);
 }
 
-bool SystemImpl::set_param_int(const std::string &name, int32_t value)
+MAVLinkParameters::Result SystemImpl::set_param_int(const std::string &name, int32_t value)
 {
     MAVLinkParameters::ParamValue param_value;
     param_value.set_int32(value);
@@ -587,7 +587,7 @@ bool SystemImpl::set_param_int(const std::string &name, int32_t value)
     return _params.set_param(name, param_value, false);
 }
 
-bool SystemImpl::set_param_ext_float(const std::string &name, float value)
+MAVLinkParameters::Result SystemImpl::set_param_ext_float(const std::string &name, float value)
 {
     MAVLinkParameters::ParamValue param_value;
     param_value.set_float(value);
@@ -595,7 +595,7 @@ bool SystemImpl::set_param_ext_float(const std::string &name, float value)
     return _params.set_param(name, param_value, true);
 }
 
-bool SystemImpl::set_param_ext_int(const std::string &name, int32_t value)
+MAVLinkParameters::Result SystemImpl::set_param_ext_int(const std::string &name, int32_t value)
 {
     MAVLinkParameters::ParamValue param_value;
     param_value.set_int32(value);
@@ -631,86 +631,92 @@ void SystemImpl::set_param_ext_int_async(const std::string &name, int32_t value,
     _params.set_param_async(name, param_value, callback, true);
 }
 
-std::pair<bool, float> SystemImpl::get_param_float(const std::string &name)
+std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(const std::string &name)
 {
-    auto prom = std::make_shared<std::promise<std::pair<bool, float>>>();
+    auto prom = std::make_shared<std::promise<std::pair<MAVLinkParameters::Result, float>>>();
     auto res = prom->get_future();
 
     MAVLinkParameters::ParamValue value_type;
     value_type.set_float(0.0f);
 
     _params.get_param_async(
-        name, value_type, [&prom](bool success, MAVLinkParameters::ParamValue param) {
+        name,
+        value_type,
+        [&prom](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue param) {
             float value = NAN;
-            if (success) {
+            if (result == MAVLinkParameters::Result::SUCCESS) {
                 value = param.get_float();
             }
-            prom->set_value(std::make_pair<>(success, value));
+            prom->set_value(std::make_pair<>(result, value));
         });
 
     return res.get();
 }
 
-std::pair<bool, int> SystemImpl::get_param_int(const std::string &name)
+std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::string &name)
 {
-    auto prom = std::make_shared<std::promise<std::pair<bool, int>>>();
+    auto prom = std::make_shared<std::promise<std::pair<MAVLinkParameters::Result, int>>>();
     auto res = prom->get_future();
 
     MAVLinkParameters::ParamValue value_type;
     value_type.set_int32(0);
 
     _params.get_param_async(
-        name, value_type, [&prom](bool success, MAVLinkParameters::ParamValue param) {
+        name,
+        value_type,
+        [&prom](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue param) {
             int value = 0;
-            if (success) {
+            if (result == MAVLinkParameters::Result::SUCCESS) {
                 value = param.get_int32();
             }
-            prom->set_value(std::make_pair<>(success, value));
+            prom->set_value(std::make_pair<>(result, value));
         });
 
     return res.get();
 }
 
-std::pair<bool, float> SystemImpl::get_param_ext_float(const std::string &name)
+std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_ext_float(const std::string &name)
 {
-    auto prom = std::make_shared<std::promise<std::pair<bool, float>>>();
+    auto prom = std::make_shared<std::promise<std::pair<MAVLinkParameters::Result, float>>>();
     auto res = prom->get_future();
 
     MAVLinkParameters::ParamValue value_type;
     value_type.set_float(0.0f);
 
-    _params.get_param_async(name,
-                            value_type,
-                            [&prom](bool success, MAVLinkParameters::ParamValue param) {
-                                float value = NAN;
-                                if (success) {
-                                    value = param.get_float();
-                                }
-                                prom->set_value(std::make_pair<>(success, value));
-                            },
-                            true);
+    _params.get_param_async(
+        name,
+        value_type,
+        [&prom](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue param) {
+            float value = NAN;
+            if (result == MAVLinkParameters::Result::SUCCESS) {
+                value = param.get_float();
+            }
+            prom->set_value(std::make_pair<>(result, value));
+        },
+        true);
 
     return res.get();
 }
 
-std::pair<bool, int> SystemImpl::get_param_ext_int(const std::string &name)
+std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_ext_int(const std::string &name)
 {
-    auto prom = std::make_shared<std::promise<std::pair<bool, int>>>();
+    auto prom = std::make_shared<std::promise<std::pair<MAVLinkParameters::Result, int>>>();
     auto res = prom->get_future();
 
     MAVLinkParameters::ParamValue value_type;
     value_type.set_int32(0.0f);
 
-    _params.get_param_async(name,
-                            value_type,
-                            [&prom](bool success, MAVLinkParameters::ParamValue param) {
-                                int value = 0;
-                                if (success) {
-                                    value = param.get_int32();
-                                }
-                                prom->set_value(std::make_pair<>(success, value));
-                            },
-                            true);
+    _params.get_param_async(
+        name,
+        value_type,
+        [&prom](MAVLinkParameters::Result result, MAVLinkParameters::ParamValue param) {
+            int value = 0;
+            if (result == MAVLinkParameters::Result::SUCCESS) {
+                value = param.get_int32();
+            }
+            prom->set_value(std::make_pair<>(result, value));
+        },
+        true);
 
     return res.get();
 }
@@ -760,9 +766,8 @@ void SystemImpl::set_param_async(const std::string &name,
     _params.set_param_async(name, value, callback, extended);
 }
 
-bool SystemImpl::set_param(const std::string &name,
-                           MAVLinkParameters::ParamValue value,
-                           bool extended)
+MAVLinkParameters::Result
+SystemImpl::set_param(const std::string &name, MAVLinkParameters::ParamValue value, bool extended)
 {
     return _params.set_param(name, value, extended);
 }
@@ -856,28 +861,28 @@ void SystemImpl::set_flight_mode_async(FlightMode system_mode,
     send_command_async(result.second, callback);
 }
 
-void SystemImpl::receive_float_param(bool success,
+void SystemImpl::receive_float_param(MAVLinkParameters::Result result,
                                      MAVLinkParameters::ParamValue value,
                                      get_param_float_callback_t callback)
 {
     if (callback) {
-        if (success) {
-            callback(success, value.get_float());
+        if (result == MAVLinkParameters::Result::SUCCESS) {
+            callback(result, value.get_float());
         } else {
-            callback(success, NAN);
+            callback(result, NAN);
         }
     }
 }
 
-void SystemImpl::receive_int_param(bool success,
+void SystemImpl::receive_int_param(MAVLinkParameters::Result result,
                                    MAVLinkParameters::ParamValue value,
                                    get_param_int_callback_t callback)
 {
     if (callback) {
-        if (success) {
-            callback(success, value.get_int32());
+        if (result == MAVLinkParameters::Result::SUCCESS) {
+            callback(result, value.get_int32());
         } else {
-            callback(success, 0);
+            callback(result, 0);
         }
     }
 }

--- a/core/system_impl.h
+++ b/core/system_impl.h
@@ -163,8 +163,10 @@ public:
     bool
     set_param(const std::string &name, MAVLinkParameters::ParamValue value, bool extended = false);
 
-    void
-    get_param_async(const std::string &name, get_param_callback_t callback, bool extended = false);
+    void get_param_async(const std::string &name,
+                         MAVLinkParameters::ParamValue value_type,
+                         get_param_callback_t callback,
+                         bool extended);
 
     bool is_connected() const;
 

--- a/core/system_impl.h
+++ b/core/system_impl.h
@@ -119,12 +119,12 @@ public:
 
     bool is_armed() const { return _armed; }
 
-    bool set_param_float(const std::string &name, float value);
-    bool set_param_int(const std::string &name, int32_t value);
-    bool set_param_ext_float(const std::string &name, float value);
-    bool set_param_ext_int(const std::string &name, int32_t value);
+    MAVLinkParameters::Result set_param_float(const std::string &name, float value);
+    MAVLinkParameters::Result set_param_int(const std::string &name, int32_t value);
+    MAVLinkParameters::Result set_param_ext_float(const std::string &name, float value);
+    MAVLinkParameters::Result set_param_ext_int(const std::string &name, int32_t value);
 
-    typedef std::function<void(bool success)> success_t;
+    typedef std::function<void(MAVLinkParameters::Result result)> success_t;
     void set_param_float_async(const std::string &name, float value, success_t callback);
     void set_param_int_async(const std::string &name, int32_t value, success_t callback);
     void set_param_ext_float_async(const std::string &name, float value, success_t callback);
@@ -137,13 +137,15 @@ public:
                                command_result_callback_t callback,
                                uint8_t component_id = MAV_COMP_ID_AUTOPILOT1);
 
-    typedef std::function<void(bool success, float value)> get_param_float_callback_t;
-    typedef std::function<void(bool success, int32_t value)> get_param_int_callback_t;
+    typedef std::function<void(MAVLinkParameters::Result result, float value)>
+        get_param_float_callback_t;
+    typedef std::function<void(MAVLinkParameters::Result result, int32_t value)>
+        get_param_int_callback_t;
 
-    std::pair<bool, float> get_param_float(const std::string &name);
-    std::pair<bool, int> get_param_int(const std::string &name);
-    std::pair<bool, float> get_param_ext_float(const std::string &name);
-    std::pair<bool, int> get_param_ext_int(const std::string &name);
+    std::pair<MAVLinkParameters::Result, float> get_param_float(const std::string &name);
+    std::pair<MAVLinkParameters::Result, int> get_param_int(const std::string &name);
+    std::pair<MAVLinkParameters::Result, float> get_param_ext_float(const std::string &name);
+    std::pair<MAVLinkParameters::Result, int> get_param_ext_int(const std::string &name);
 
     // These methods can be used to cache a parameter when a system connects. For that
     // the callback can just be set to nullptr.
@@ -152,7 +154,8 @@ public:
     void get_param_ext_float_async(const std::string &name, get_param_float_callback_t callback);
     void get_param_ext_int_async(const std::string &name, get_param_int_callback_t callback);
 
-    typedef std::function<void(bool success, MAVLinkParameters::ParamValue value)>
+    typedef std::function<void(MAVLinkParameters::Result result,
+                               MAVLinkParameters::ParamValue value)>
         get_param_callback_t;
 
     void set_param_async(const std::string &name,
@@ -160,7 +163,7 @@ public:
                          success_t callback,
                          bool extended = false);
 
-    bool
+    MAVLinkParameters::Result
     set_param(const std::string &name, MAVLinkParameters::ParamValue value, bool extended = false);
 
     void get_param_async(const std::string &name,
@@ -209,10 +212,10 @@ private:
     std::pair<MAVLinkCommands::Result, MAVLinkCommands::CommandLong>
     make_command_msg_rate(uint16_t message_id, double rate_hz, uint8_t component_id);
 
-    static void receive_float_param(bool success,
+    static void receive_float_param(MAVLinkParameters::Result result,
                                     MAVLinkParameters::ParamValue value,
                                     get_param_float_callback_t callback);
-    static void receive_int_param(bool success,
+    static void receive_int_param(MAVLinkParameters::Result result,
                                   MAVLinkParameters::ParamValue value,
                                   get_param_int_callback_t callback);
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(integration_tests_runner
     mission_rtl.cpp
     mission_survey.cpp
     offboard_velocity.cpp
+    params_raw.cpp
     path_checker.cpp
     path_checker.h
     system_connection_async.cpp
@@ -70,6 +71,7 @@ target_link_libraries(integration_tests_runner
     dronecode_sdk_follow_me
     dronecode_sdk_camera
     dronecode_sdk_calibration
+    dronecode_sdk_params_raw
     gtest
     gtest_main
     gmock

--- a/integration_tests/params_raw.cpp
+++ b/integration_tests/params_raw.cpp
@@ -20,19 +20,22 @@ TEST_F(SitlTest, ParamsRawSad)
 
     auto params_raw = std::make_shared<ParamsRaw>(system);
 
-    // TODO: It would be nicer if the plugin would return `WRONG_TYPE` instead of just `ERROR`
-    //       for these cases.
-
     {
         const std::pair<ParamsRaw::Result, float> get_result =
             params_raw->get_param_float("SYS_HITL");
-        EXPECT_EQ(get_result.first, ParamsRaw::Result::ERROR);
+        EXPECT_EQ(get_result.first, ParamsRaw::Result::WRONG_TYPE);
     }
 
     {
         const std::pair<ParamsRaw::Result, int32_t> get_result =
             params_raw->get_param_int("COM_RC_LOSS_MAN");
-        EXPECT_EQ(get_result.first, ParamsRaw::Result::ERROR);
+        EXPECT_EQ(get_result.first, ParamsRaw::Result::WRONG_TYPE);
+    }
+
+    {
+        const std::pair<ParamsRaw::Result, int32_t> get_result =
+            params_raw->get_param_int("NAME_TOO_LOOOOONG");
+        EXPECT_EQ(get_result.first, ParamsRaw::Result::PARAM_NAME_TOO_LONG);
     }
 }
 

--- a/integration_tests/params_raw.cpp
+++ b/integration_tests/params_raw.cpp
@@ -1,0 +1,122 @@
+#include <iostream>
+#include "integration_test_helper.h"
+#include "dronecode_sdk.h"
+#include "plugins/params_raw/params_raw.h"
+
+using namespace dronecode_sdk;
+
+TEST_F(SitlTest, ParamsRawSad)
+{
+    DronecodeSDK dc;
+
+    ConnectionResult ret = dc.add_udp_connection();
+    ASSERT_EQ(ret, ConnectionResult::SUCCESS);
+
+    // Wait for system to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    auto &system = dc.system();
+    ASSERT_TRUE(system.has_autopilot());
+
+    auto params_raw = std::make_shared<ParamsRaw>(system);
+
+    // TODO: It would be nicer if the plugin would return `WRONG_TYPE` instead of just `ERROR`
+    //       for these cases.
+
+    {
+        const std::pair<ParamsRaw::Result, float> get_result =
+            params_raw->get_param_float("SYS_HITL");
+        EXPECT_EQ(get_result.first, ParamsRaw::Result::ERROR);
+    }
+
+    {
+        const std::pair<ParamsRaw::Result, int32_t> get_result =
+            params_raw->get_param_int("COM_RC_LOSS_MAN");
+        EXPECT_EQ(get_result.first, ParamsRaw::Result::ERROR);
+    }
+}
+
+TEST_F(SitlTest, ParamsRawHappy)
+{
+    DronecodeSDK dc;
+
+    ConnectionResult ret = dc.add_udp_connection();
+    ASSERT_EQ(ret, ConnectionResult::SUCCESS);
+
+    // Wait for system to connect via heartbeat.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    auto &system = dc.system();
+    ASSERT_TRUE(system.has_autopilot());
+
+    auto params_raw = std::make_shared<ParamsRaw>(system);
+
+    {
+        const std::pair<ParamsRaw::Result, int> get_result1 = params_raw->get_param_int("SYS_HITL");
+
+        // Get initial value.
+        ASSERT_EQ(get_result1.first, ParamsRaw::Result::SUCCESS);
+        ASSERT_GE(get_result1.second, 0);
+        ASSERT_LE(get_result1.second, 1);
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        // Toggle the value.
+        const ParamsRaw::Result set_result1 =
+            params_raw->set_param_int("SYS_HITL", !get_result1.second);
+        EXPECT_EQ(set_result1, ParamsRaw::Result::SUCCESS);
+
+        // Verify toggle.
+        const std::pair<ParamsRaw::Result, int> get_result2 = params_raw->get_param_int("SYS_HITL");
+        EXPECT_EQ(get_result2.first, ParamsRaw::Result::SUCCESS);
+        EXPECT_EQ(get_result2.second, !get_result1.second);
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        // Reset back to initial value.
+        const ParamsRaw::Result set_result2 =
+            params_raw->set_param_int("SYS_HITL", get_result1.second);
+        EXPECT_EQ(set_result2, ParamsRaw::Result::SUCCESS);
+
+        // Verify reset.
+        const std::pair<ParamsRaw::Result, int> get_result3 = params_raw->get_param_int("SYS_HITL");
+        EXPECT_EQ(get_result3.first, ParamsRaw::Result::SUCCESS);
+        EXPECT_EQ(get_result3.second, get_result1.second);
+    }
+
+    {
+        const std::pair<ParamsRaw::Result, float> get_result1 =
+            params_raw->get_param_float("COM_RC_LOSS_MAN");
+
+        // Get initial value.
+        ASSERT_EQ(get_result1.first, ParamsRaw::Result::SUCCESS);
+        ASSERT_GE(get_result1.second, 0);
+        ASSERT_LE(get_result1.second, 1);
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        // Toggle the value.
+        const ParamsRaw::Result set_result1 =
+            params_raw->set_param_float("COM_RC_LOSS_MAN", get_result1.second + 1.0f);
+        EXPECT_EQ(set_result1, ParamsRaw::Result::SUCCESS);
+
+        // Verify toggle.
+        const std::pair<ParamsRaw::Result, float> get_result2 =
+            params_raw->get_param_float("COM_RC_LOSS_MAN");
+        EXPECT_EQ(get_result2.first, ParamsRaw::Result::SUCCESS);
+        EXPECT_FLOAT_EQ(get_result2.second, get_result1.second + 1.0f);
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        // Reset back to initial value.
+        const ParamsRaw::Result set_result2 =
+            params_raw->set_param_float("COM_RC_LOSS_MAN", get_result1.second);
+        EXPECT_EQ(set_result2, ParamsRaw::Result::SUCCESS);
+
+        // Verify reset.
+        const std::pair<ParamsRaw::Result, float> get_result3 =
+            params_raw->get_param_float("COM_RC_LOSS_MAN");
+        EXPECT_EQ(get_result3.first, ParamsRaw::Result::SUCCESS);
+        EXPECT_FLOAT_EQ(get_result3.second, get_result1.second);
+    }
+}

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -19,6 +19,7 @@ add_subdirectory(log_files)
 #add_subdirectory(logging) # Not implemented completely
 add_subdirectory(mission)
 add_subdirectory(offboard)
+add_subdirectory(params_raw)
 add_subdirectory(telemetry)
 
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -450,40 +450,51 @@ void ActionImpl::loiter_before_arm_async(const Action::result_callback_t &callba
 
 ActionResult ActionImpl::set_takeoff_altitude(float relative_altitude_m)
 {
-    const bool success = _parent->set_param_float(TAKEOFF_ALT_PARAM, relative_altitude_m);
-    return success ? ActionResult::SUCCESS : ActionResult::PARAMETER_ERROR;
+    const MAVLinkParameters::Result result =
+        _parent->set_param_float(TAKEOFF_ALT_PARAM, relative_altitude_m);
+    return (result == MAVLinkParameters::Result::SUCCESS) ? ActionResult::SUCCESS :
+                                                            ActionResult::PARAMETER_ERROR;
 }
 
 std::pair<ActionResult, float> ActionImpl::get_takeoff_altitude() const
 {
     auto result = _parent->get_param_float(TAKEOFF_ALT_PARAM);
-    return std::make_pair<>(result.first ? ActionResult::SUCCESS : ActionResult::PARAMETER_ERROR,
+    return std::make_pair<>((result.first == MAVLinkParameters::Result::SUCCESS) ?
+                                ActionResult::SUCCESS :
+                                ActionResult::PARAMETER_ERROR,
                             result.second);
 }
 
 ActionResult ActionImpl::set_max_speed(float speed_m_s)
 {
-    const bool success = _parent->set_param_float(MAX_SPEED_PARAM, speed_m_s);
-    return success ? ActionResult::SUCCESS : ActionResult::PARAMETER_ERROR;
+    const MAVLinkParameters::Result result = _parent->set_param_float(MAX_SPEED_PARAM, speed_m_s);
+    return (result == MAVLinkParameters::Result::SUCCESS) ? ActionResult::SUCCESS :
+                                                            ActionResult::PARAMETER_ERROR;
 }
 
 std::pair<ActionResult, float> ActionImpl::get_max_speed() const
 {
     auto result = _parent->get_param_float(MAX_SPEED_PARAM);
-    return std::make_pair<>(result.first ? ActionResult::SUCCESS : ActionResult::PARAMETER_ERROR,
+    return std::make_pair<>((result.first == MAVLinkParameters::Result::SUCCESS) ?
+                                ActionResult::SUCCESS :
+                                ActionResult::PARAMETER_ERROR,
                             result.second);
 }
 
 ActionResult ActionImpl::set_return_to_launch_return_altitude(float relative_altitude_m)
 {
-    const bool success = _parent->set_param_float(RTL_RETURN_ALTITUDE_PARAM, relative_altitude_m);
-    return success ? ActionResult::SUCCESS : ActionResult::PARAMETER_ERROR;
+    const MAVLinkParameters::Result result =
+        _parent->set_param_float(RTL_RETURN_ALTITUDE_PARAM, relative_altitude_m);
+    return (result == MAVLinkParameters::Result::SUCCESS) ? ActionResult::SUCCESS :
+                                                            ActionResult::PARAMETER_ERROR;
 }
 
 std::pair<ActionResult, float> ActionImpl::get_return_to_launch_return_altitude() const
 {
     auto result = _parent->get_param_float(RTL_RETURN_ALTITUDE_PARAM);
-    return std::make_pair<>(result.first ? ActionResult::SUCCESS : ActionResult::PARAMETER_ERROR,
+    return std::make_pair<>((result.first == MAVLinkParameters::Result::SUCCESS) ?
+                                ActionResult::SUCCESS :
+                                ActionResult::PARAMETER_ERROR,
                             result.second);
 }
 

--- a/plugins/calibration/calibration_impl.cpp
+++ b/plugins/calibration/calibration_impl.cpp
@@ -259,9 +259,9 @@ CalibrationImpl::calibration_result_from_command_result(MAVLinkCommands::Result 
     }
 }
 
-void CalibrationImpl::receive_param_cal_gyro(bool success, int value)
+void CalibrationImpl::receive_param_cal_gyro(MAVLinkParameters::Result result, int value)
 {
-    if (!success) {
+    if (result != MAVLinkParameters::Result::SUCCESS) {
         LogErr() << "Error: Param for gyro cal failed.";
         return;
     }
@@ -270,9 +270,9 @@ void CalibrationImpl::receive_param_cal_gyro(bool success, int value)
     set_gyro_calibration(ok);
 }
 
-void CalibrationImpl::receive_param_cal_accel(bool success, int value)
+void CalibrationImpl::receive_param_cal_accel(MAVLinkParameters::Result result, int value)
 {
-    if (!success) {
+    if (result != MAVLinkParameters::Result::SUCCESS) {
         LogErr() << "Error: Param for accel cal failed.";
         return;
     }
@@ -281,9 +281,9 @@ void CalibrationImpl::receive_param_cal_accel(bool success, int value)
     set_accelerometer_calibration(ok);
 }
 
-void CalibrationImpl::receive_param_cal_mag(bool success, int value)
+void CalibrationImpl::receive_param_cal_mag(MAVLinkParameters::Result result, int value)
 {
-    if (!success) {
+    if (result != MAVLinkParameters::Result::SUCCESS) {
         LogErr() << "Error: Param for mag cal failed.";
         return;
     }

--- a/plugins/calibration/calibration_impl.h
+++ b/plugins/calibration/calibration_impl.h
@@ -39,9 +39,9 @@ private:
     static Calibration::Result
     calibration_result_from_command_result(MAVLinkCommands::Result result);
 
-    void receive_param_cal_gyro(bool success, int value);
-    void receive_param_cal_accel(bool success, int value);
-    void receive_param_cal_mag(bool success, int value);
+    void receive_param_cal_gyro(MAVLinkParameters::Result result, int value);
+    void receive_param_cal_accel(MAVLinkParameters::Result result, int value);
+    void receive_param_cal_mag(MAVLinkParameters::Result result, int value);
 
     void set_gyro_calibration(bool ok);
     void set_accelerometer_calibration(bool ok);

--- a/plugins/camera/camera_definition.cpp
+++ b/plugins/camera/camera_definition.cpp
@@ -105,6 +105,27 @@ bool CameraDefinition::parse_xml()
             return false;
         }
 
+        const char *type_str = e_parameter->Attribute("type");
+        if (!type_str) {
+            LogErr() << "type attribute missing";
+            return false;
+        }
+
+        if (strcmp(type_str, "string") == 0) {
+            LogDebug() << "Ignoring string params.";
+            continue;
+        }
+
+        if (strcmp(type_str, "custom") == 0) {
+            LogDebug() << "Ignoring custom params.";
+            continue;
+        }
+
+        if (!new_parameter->type.set_empty_type_from_xml(type_str)) {
+            LogErr() << "unknown type attribute";
+            return false;
+        }
+
         // By default control is on.
         new_parameter->is_control = true;
         const char *control_str = e_parameter->Attribute("control");
@@ -542,13 +563,14 @@ bool CameraDefinition::get_possible_options(const std::string &name,
     return true;
 }
 
-void CameraDefinition::get_unknown_params(std::vector<std::string> &params)
+void CameraDefinition::get_unknown_params(
+    std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> &params)
 {
     params.clear();
 
     for (const auto &parameter : _parameter_map) {
         if (_current_settings[parameter.first].needs_updating) {
-            params.push_back(parameter.first);
+            params.push_back(std::make_pair<>(parameter.first, parameter.second->type));
         }
     }
 }

--- a/plugins/camera/camera_definition.h
+++ b/plugins/camera/camera_definition.h
@@ -45,7 +45,8 @@ public:
                         const std::string &option_name,
                         std::string &description);
 
-    void get_unknown_params(std::vector<std::string> &params);
+    void
+    get_unknown_params(std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> &params);
     void set_all_params_unknown();
 
     // Non-copyable
@@ -68,6 +69,7 @@ private:
         bool is_control;
         bool is_readonly;
         bool is_writeonly;
+        MAVLinkParameters::ParamValue type; // for type only, doesn't hold a value
         std::vector<std::string> updates;
         std::vector<std::shared_ptr<Option>> options;
     };

--- a/plugins/camera/camera_definition_test.cpp
+++ b/plugins/camera/camera_definition_test.cpp
@@ -281,11 +281,11 @@ TEST(CameraDefinition, E90SettingsToUpdate)
     ASSERT_TRUE(cd.load_file(e90_unit_test_file));
 
     {
-        std::vector<std::string> params;
+        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 16);
         for (const auto &param : params) {
-            LogInfo() << param;
+            LogInfo() << param.first;
         }
     }
 
@@ -297,7 +297,7 @@ TEST(CameraDefinition, E90SettingsToUpdate)
 
     // Now that we set one param it should be less that we need to fetch.
     {
-        std::vector<std::string> params;
+        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 15);
     }
@@ -305,7 +305,7 @@ TEST(CameraDefinition, E90SettingsToUpdate)
     cd.set_all_params_unknown();
 
     {
-        std::vector<std::string> params;
+        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 16);
     }
@@ -320,11 +320,11 @@ TEST(CameraDefinition, E90SettingsCauseUpdates)
     cd.assume_default_settings();
 
     {
-        std::vector<std::string> params;
+        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 0);
         for (const auto &param : params) {
-            LogInfo() << param;
+            LogInfo() << param.first;
         }
     }
 
@@ -336,7 +336,7 @@ TEST(CameraDefinition, E90SettingsCauseUpdates)
 
     // Now that we set one param it should be less that we need to fetch.
     {
-        std::vector<std::string> params;
+        std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
         cd.get_unknown_params(params);
         EXPECT_EQ(params.size(), 4);
 
@@ -348,20 +348,20 @@ TEST(CameraDefinition, E90SettingsCauseUpdates)
         bool found_photoratio = false;
 
         for (const auto &param : params) {
-            if (strcmp("CAM_SHUTTERSPD", param.c_str()) == 0) {
+            if (strcmp("CAM_SHUTTERSPD", param.first.c_str()) == 0) {
                 found_shutterspd = true;
             }
-            if (strcmp("CAM_ISO", param.c_str()) == 0) {
+            if (strcmp("CAM_ISO", param.first.c_str()) == 0) {
                 found_iso = true;
             }
-            if (strcmp("CAM_VIDRES", param.c_str()) == 0) {
+            if (strcmp("CAM_VIDRES", param.first.c_str()) == 0) {
                 found_vidres = true;
             }
             // We don't yet handle ASPECTRATIO
-            // if (strcmp("CAM_ASPECTRATIO", param.c_str()) == 0) {
+            // if (strcmp("CAM_ASPECTRATIO", param.first.c_str()) == 0) {
             //    found_aspectratio = true;
             //}
-            if (strcmp("CAM_PHOTORATIO", param.c_str()) == 0) {
+            if (strcmp("CAM_PHOTORATIO", param.first.c_str()) == 0) {
                 found_photoratio = true;
             }
         }

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -1244,25 +1244,11 @@ void CameraImpl::get_option_async(const std::string &setting_id,
         }
     } else {
         // If this still happens, we request the param, but also complain.
-        LogWarn() << "The param was probably outdated, trying to fetch it";
-        _parent->get_param_async(
-            setting_id,
-            [setting_id, this](bool success, MAVLinkParameters::ParamValue value_gotten) {
-                if (!success) {
-                    LogWarn() << "Fetching the param failed";
-                    return;
-                }
-                // We need to check again by the time this callback runs
-                if (!this->_camera_definition) {
-                    return;
-                }
-                this->_camera_definition->set_setting(setting_id, value_gotten);
-            },
-            true);
-
-        // At this point it might be a good idea to refresh but it's a bit scary
-        // as the stack keeps growing at this point.
-        // refresh_params();
+        LogWarn() << "Setting '" << setting_id << "' not found.";
+        if (callback) {
+            Camera::Option no_option{};
+            callback(Camera::Result::ERROR, no_option);
+        }
     }
 }
 

--- a/plugins/camera/camera_impl.cpp
+++ b/plugins/camera/camera_impl.cpp
@@ -1350,7 +1350,7 @@ void CameraImpl::refresh_params()
         return;
     }
 
-    std::vector<std::string> params{};
+    std::vector<std::pair<std::string, MAVLinkParameters::ParamValue>> params;
     _camera_definition->get_unknown_params(params);
     if (params.size() == 0) {
         // We're assuming that we changed one option and this did not cause
@@ -1362,10 +1362,12 @@ void CameraImpl::refresh_params()
 
     unsigned count = 0;
     for (const auto &param : params) {
-        std::string param_name = param;
+        const std::string &param_name = param.first;
+        const MAVLinkParameters::ParamValue &param_value_type = param.second;
         const bool is_last = (count + 1 == params.size());
         _parent->get_param_async(
             param_name,
+            param_value_type,
             [param_name, is_last, this](bool success, MAVLinkParameters::ParamValue value) {
                 if (!success) {
                     return;

--- a/plugins/follow_me/follow_me_impl.cpp
+++ b/plugins/follow_me/follow_me_impl.cpp
@@ -33,26 +33,30 @@ void FollowMeImpl::deinit()
 
 void FollowMeImpl::enable()
 {
-    _parent->get_param_float_async("NAV_MIN_FT_HT", [this](bool success, float value) {
-        if (success) {
-            _config.min_height_m = value;
-        }
-    });
-    _parent->get_param_float_async("NAV_FT_DST", [this](bool success, float value) {
-        if (success) {
-            _config.follow_distance_m = value;
-        }
-    });
-    _parent->get_param_int_async("NAV_FT_FS", [this](bool success, int32_t value) {
-        if (success) {
-            _config.follow_direction = static_cast<FollowMe::Config::FollowDirection>(value);
-        }
-    });
-    _parent->get_param_float_async("NAV_FT_RS", [this](bool success, float value) {
-        if (success) {
-            _config.responsiveness = value;
-        }
-    });
+    _parent->get_param_float_async("NAV_MIN_FT_HT",
+                                   [this](MAVLinkParameters::Result result, float value) {
+                                       if (result == MAVLinkParameters::Result::SUCCESS) {
+                                           _config.min_height_m = value;
+                                       }
+                                   });
+    _parent->get_param_float_async("NAV_FT_DST",
+                                   [this](MAVLinkParameters::Result result, float value) {
+                                       if (result == MAVLinkParameters::Result::SUCCESS) {
+                                           _config.follow_distance_m = value;
+                                       }
+                                   });
+    _parent->get_param_int_async(
+        "NAV_FT_FS", [this](MAVLinkParameters::Result result, int32_t value) {
+            if (result == MAVLinkParameters::Result::SUCCESS) {
+                _config.follow_direction = static_cast<FollowMe::Config::FollowDirection>(value);
+            }
+        });
+    _parent->get_param_float_async("NAV_FT_RS",
+                                   [this](MAVLinkParameters::Result result, float value) {
+                                       if (result == MAVLinkParameters::Result::SUCCESS) {
+                                           _config.responsiveness = value;
+                                       }
+                                   });
 }
 
 void FollowMeImpl::disable()
@@ -84,21 +88,23 @@ FollowMe::Result FollowMeImpl::set_config(const FollowMe::Config &config)
 
     // Send configuration to Vehicle
     if (_config.min_height_m != height) {
-        if (_parent->set_param_float("NAV_MIN_FT_HT", height)) {
+        if (_parent->set_param_float("NAV_MIN_FT_HT", height) ==
+            MAVLinkParameters::Result::SUCCESS) {
             _config.min_height_m = height;
         } else {
             success = false;
         }
     }
     if (_config.follow_distance_m != distance) {
-        if (_parent->set_param_float("NAV_FT_DST", distance)) {
+        if (_parent->set_param_float("NAV_FT_DST", distance) ==
+            MAVLinkParameters::Result::SUCCESS) {
             _config.follow_distance_m = distance;
         } else {
             success = false;
         }
     }
     if (_config.follow_direction != config.follow_direction) {
-        if (_parent->set_param_int("NAV_FT_FS", direction)) {
+        if (_parent->set_param_int("NAV_FT_FS", direction) == MAVLinkParameters::Result::SUCCESS) {
             _config.follow_direction = static_cast<FollowMe::Config::FollowDirection>(direction);
 
         } else {
@@ -106,7 +112,8 @@ FollowMe::Result FollowMeImpl::set_config(const FollowMe::Config &config)
         }
     }
     if (_config.responsiveness != responsiveness) {
-        if (_parent->set_param_float("NAV_FT_RS", responsiveness)) {
+        if (_parent->set_param_float("NAV_FT_RS", responsiveness) ==
+            MAVLinkParameters::Result::SUCCESS) {
             _config.responsiveness = responsiveness;
         } else {
             success = false;

--- a/plugins/params_raw/CMakeLists.txt
+++ b/plugins/params_raw/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_library(dronecode_sdk_params_raw ${PLUGIN_LIBRARY_TYPE}
+    params_raw.cpp
+    params_raw_impl.cpp
+)
+
+target_link_libraries(dronecode_sdk_params_raw
+    dronecode_sdk
+)
+
+set_target_properties(dronecode_sdk_params_raw
+    PROPERTIES COMPILE_FLAGS ${warnings}
+)
+
+install(FILES
+    include/plugins/params_raw/params_raw.h
+    DESTINATION ${dronecode_sdk_install_include_dir}
+)
+
+install(TARGETS dronecode_sdk_params_raw
+    #EXPORT dronecode_sdk-targets
+    DESTINATION ${dronecode_sdk_install_lib_dir}
+)
+
+target_include_directories(dronecode_sdk_params_raw
+PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/plugins/params_raw/include/plugins/params_raw/params_raw.h
+++ b/plugins/params_raw/include/plugins/params_raw/params_raw.h
@@ -39,9 +39,19 @@ public:
     enum class Result {
         UNKNOWN, /**< @brief Unknown error. */
         SUCCESS, /**< @brief %Request succeeded. */
-        ERROR, /**< @brief Error. */
-        TIMEOUT /**< @brief Request timed out. */
+        TIMEOUT, /**< @brief Request timed out. */
+        CONNECTION_ERROR, /**< @brief Connection error. */
+        WRONG_TYPE, /**< @brief Error. */
+        PARAM_NAME_TOO_LONG /**< @brief Parameter name too long (> 16). */
     };
+
+    /**
+     * @brief Returns a human-readable English string for `ParamsRaw::Result`.
+     *
+     * @param result The enum value for which a human readable string is required.
+     * @return Human readable string for the `ParamsRaw::Result`.
+     */
+    std::string result_str(Result result);
 
     /**
      * @brief Get an int parameter.

--- a/plugins/params_raw/include/plugins/params_raw/params_raw.h
+++ b/plugins/params_raw/include/plugins/params_raw/params_raw.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include "plugin_base.h"
+
+namespace dronecode_sdk {
+
+class System;
+class ParamsRawImpl;
+
+/**
+ * @brief The ParamsRaw class provides raw access to get and set parameters.
+ */
+class ParamsRaw : public PluginBase {
+public:
+    /**
+     * @brief Constructor. Creates the plugin for a specific System.
+     *
+     * The plugin is typically created as shown below:
+     *
+     *     ```cpp
+     *     auto info = std::make_shared<ParamsRaw>(system);
+     *     ```
+     *
+     * @param system The specific system associated with this plugin.
+     */
+    explicit ParamsRaw(System &system);
+
+    /**
+     * @brief Destructor (internal use only).
+     */
+    ~ParamsRaw();
+
+    /**
+     * @brief Possible results returned for params_raw requests.
+     */
+    enum class Result {
+        UNKNOWN, /**< @brief Unknown error. */
+        SUCCESS, /**< @brief %Request succeeded. */
+        ERROR, /**< @brief Error. */
+        TIMEOUT /**< @brief Request timed out. */
+    };
+
+    /**
+     * @brief Get an int parameter.
+     *
+     * If the type is wrong, the result will be `Result::WRONG_TYPE`.
+     *
+     * @return a pair of the result of the request and the param (if successful).
+     */
+    std::pair<Result, int32_t> get_param_int(const std::string &name);
+
+    /**
+     * @brief Set an int parameter.
+     *
+     * If the type is wrong, the result will be `Result::WRONG_TYPE`.
+     *
+     * @return result of the request.
+     */
+    Result set_param_int(const std::string &name, int32_t value);
+
+    /**
+     * @brief Get a float parameter.
+     *
+     * If the type is wrong, the result will be `Result::WRONG_TYPE`.
+     *
+     * @return a pair of the result of the request and the param (if successful).
+     */
+    std::pair<Result, float> get_param_float(const std::string &name);
+
+    /**
+     * @brief Set a float parameter.
+     *
+     * If the type is wrong, the result will be `Result::WRONG_TYPE`.
+     *
+     * @return result of the request.
+     */
+    Result set_param_float(const std::string &name, float value);
+
+    /**
+     * @brief Copy Constructor (object is not copyable).
+     */
+    ParamsRaw(const ParamsRaw &) = delete;
+    /**
+     * @brief Equality operator (object is not copyable).
+     */
+    const ParamsRaw &operator=(const ParamsRaw &) = delete;
+
+private:
+    /** @private Underlying implementation, set at instantiation */
+    std::unique_ptr<ParamsRawImpl> _impl;
+};
+
+} // namespace dronecode_sdk

--- a/plugins/params_raw/params_raw.cpp
+++ b/plugins/params_raw/params_raw.cpp
@@ -1,0 +1,30 @@
+#include "plugins/params_raw/params_raw.h"
+#include "params_raw_impl.h"
+
+namespace dronecode_sdk {
+
+ParamsRaw::ParamsRaw(System &system) : PluginBase(), _impl{new ParamsRawImpl(system)} {}
+
+ParamsRaw::~ParamsRaw() {}
+
+std::pair<ParamsRaw::Result, int32_t> ParamsRaw::get_param_int(const std::string &name)
+{
+    return _impl->get_param_int(name);
+}
+
+ParamsRaw::Result ParamsRaw::set_param_int(const std::string &name, int32_t value)
+{
+    return _impl->set_param_int(name, value);
+}
+
+std::pair<ParamsRaw::Result, float> ParamsRaw::get_param_float(const std::string &name)
+{
+    return _impl->get_param_float(name);
+}
+
+ParamsRaw::Result ParamsRaw::set_param_float(const std::string &name, float value)
+{
+    return _impl->set_param_float(name, value);
+}
+
+} // namespace dronecode_sdk

--- a/plugins/params_raw/params_raw.cpp
+++ b/plugins/params_raw/params_raw.cpp
@@ -27,4 +27,24 @@ ParamsRaw::Result ParamsRaw::set_param_float(const std::string &name, float valu
     return _impl->set_param_float(name, value);
 }
 
+std::string ParamsRaw::result_str(Result result)
+{
+    switch (result) {
+        case ParamsRaw::Result::SUCCESS:
+            return "Success";
+        case ParamsRaw::Result::TIMEOUT:
+            return "Timeout";
+        case ParamsRaw::Result::CONNECTION_ERROR:
+            return "Connection error";
+        case ParamsRaw::Result::WRONG_TYPE:
+            return "Wrong type";
+        case ParamsRaw::Result::PARAM_NAME_TOO_LONG:
+            return "Param name too long";
+        default:
+            // FALLTHROUGH
+        case ParamsRaw::Result::UNKNOWN:
+            return "Unknown";
+    }
+}
+
 } // namespace dronecode_sdk

--- a/plugins/params_raw/params_raw_impl.cpp
+++ b/plugins/params_raw/params_raw_impl.cpp
@@ -25,41 +25,45 @@ void ParamsRawImpl::disable() {}
 
 std::pair<ParamsRaw::Result, int32_t> ParamsRawImpl::get_param_int(const std::string &name)
 {
-    std::pair<bool, int32_t> result = _parent->get_param_int(name);
-    if (result.first) {
-        return std::make_pair<>(ParamsRaw::Result::SUCCESS, result.second);
-    } else {
-        return std::make_pair<>(ParamsRaw::Result::ERROR, result.second);
-    }
+    std::pair<MAVLinkParameters::Result, int32_t> result = _parent->get_param_int(name);
+    return std::make_pair<>(result_from_mavlink_parameters_result(result.first), result.second);
 }
 
 ParamsRaw::Result ParamsRawImpl::set_param_int(const std::string &name, int32_t value)
 {
-    bool result = _parent->set_param_int(name, value);
-    if (result) {
-        return ParamsRaw::Result::SUCCESS;
-    } else {
-        return ParamsRaw::Result::ERROR;
-    }
+    MAVLinkParameters::Result result = _parent->set_param_int(name, value);
+    return result_from_mavlink_parameters_result(result);
 }
 
 std::pair<ParamsRaw::Result, float> ParamsRawImpl::get_param_float(const std::string &name)
 {
-    std::pair<bool, float> result = _parent->get_param_float(name);
-    if (result.first) {
-        return std::make_pair<>(ParamsRaw::Result::SUCCESS, result.second);
-    } else {
-        return std::make_pair<>(ParamsRaw::Result::ERROR, result.second);
-    }
+    std::pair<MAVLinkParameters::Result, int32_t> result = _parent->get_param_float(name);
+    return std::make_pair<>(result_from_mavlink_parameters_result(result.first), result.second);
 }
 
 ParamsRaw::Result ParamsRawImpl::set_param_float(const std::string &name, float value)
 {
-    bool result = _parent->set_param_float(name, value);
-    if (result) {
-        return ParamsRaw::Result::SUCCESS;
-    } else {
-        return ParamsRaw::Result::ERROR;
+    MAVLinkParameters::Result result = _parent->set_param_float(name, value);
+    return result_from_mavlink_parameters_result(result);
+}
+
+ParamsRaw::Result
+ParamsRawImpl::result_from_mavlink_parameters_result(MAVLinkParameters::Result result)
+{
+    switch (result) {
+        case MAVLinkParameters::Result::SUCCESS:
+            return ParamsRaw::Result::SUCCESS;
+        case MAVLinkParameters::Result::TIMEOUT:
+            return ParamsRaw::Result::TIMEOUT;
+        case MAVLinkParameters::Result::PARAM_NAME_TOO_LONG:
+            return ParamsRaw::Result::PARAM_NAME_TOO_LONG;
+        case MAVLinkParameters::Result::WRONG_TYPE:
+            return ParamsRaw::Result::WRONG_TYPE;
+        case MAVLinkParameters::Result::CONNECTION_ERROR:
+            return ParamsRaw::Result::CONNECTION_ERROR;
+        default:
+            LogErr() << "Unknown param error";
+            return ParamsRaw::Result::UNKNOWN;
     }
 }
 

--- a/plugins/params_raw/params_raw_impl.cpp
+++ b/plugins/params_raw/params_raw_impl.cpp
@@ -1,0 +1,66 @@
+#include <functional>
+#include "params_raw_impl.h"
+#include "system.h"
+#include "global_include.h"
+
+namespace dronecode_sdk {
+
+ParamsRawImpl::ParamsRawImpl(System &system) : PluginImplBase(system)
+{
+    _parent->register_plugin(this);
+}
+
+ParamsRawImpl::~ParamsRawImpl()
+{
+    _parent->unregister_plugin(this);
+}
+
+void ParamsRawImpl::init() {}
+
+void ParamsRawImpl::deinit() {}
+
+void ParamsRawImpl::enable() {}
+
+void ParamsRawImpl::disable() {}
+
+std::pair<ParamsRaw::Result, int32_t> ParamsRawImpl::get_param_int(const std::string &name)
+{
+    std::pair<bool, int32_t> result = _parent->get_param_int(name);
+    if (result.first) {
+        return std::make_pair<>(ParamsRaw::Result::SUCCESS, result.second);
+    } else {
+        return std::make_pair<>(ParamsRaw::Result::ERROR, result.second);
+    }
+}
+
+ParamsRaw::Result ParamsRawImpl::set_param_int(const std::string &name, int32_t value)
+{
+    bool result = _parent->set_param_int(name, value);
+    if (result) {
+        return ParamsRaw::Result::SUCCESS;
+    } else {
+        return ParamsRaw::Result::ERROR;
+    }
+}
+
+std::pair<ParamsRaw::Result, float> ParamsRawImpl::get_param_float(const std::string &name)
+{
+    std::pair<bool, float> result = _parent->get_param_float(name);
+    if (result.first) {
+        return std::make_pair<>(ParamsRaw::Result::SUCCESS, result.second);
+    } else {
+        return std::make_pair<>(ParamsRaw::Result::ERROR, result.second);
+    }
+}
+
+ParamsRaw::Result ParamsRawImpl::set_param_float(const std::string &name, float value)
+{
+    bool result = _parent->set_param_float(name, value);
+    if (result) {
+        return ParamsRaw::Result::SUCCESS;
+    } else {
+        return ParamsRaw::Result::ERROR;
+    }
+}
+
+} // namespace dronecode_sdk

--- a/plugins/params_raw/params_raw_impl.cpp
+++ b/plugins/params_raw/params_raw_impl.cpp
@@ -37,7 +37,7 @@ ParamsRaw::Result ParamsRawImpl::set_param_int(const std::string &name, int32_t 
 
 std::pair<ParamsRaw::Result, float> ParamsRawImpl::get_param_float(const std::string &name)
 {
-    std::pair<MAVLinkParameters::Result, int32_t> result = _parent->get_param_float(name);
+    std::pair<MAVLinkParameters::Result, float> result = _parent->get_param_float(name);
     return std::make_pair<>(result_from_mavlink_parameters_result(result.first), result.second);
 }
 

--- a/plugins/params_raw/params_raw_impl.h
+++ b/plugins/params_raw/params_raw_impl.h
@@ -27,6 +27,8 @@ public:
     ParamsRaw::Result set_param_float(const std::string &name, float value);
 
 private:
+    static ParamsRaw::Result
+    result_from_mavlink_parameters_result(MAVLinkParameters::Result result);
 };
 
 } // namespace dronecode_sdk

--- a/plugins/params_raw/params_raw_impl.h
+++ b/plugins/params_raw/params_raw_impl.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "plugins/params_raw/params_raw.h"
+#include "mavlink_include.h"
+#include "plugin_impl_base.h"
+#include <mutex>
+
+namespace dronecode_sdk {
+
+class ParamsRawImpl : public PluginImplBase {
+public:
+    ParamsRawImpl(System &system);
+    ~ParamsRawImpl();
+
+    void init() override;
+    void deinit() override;
+
+    void enable() override;
+    void disable() override;
+
+    std::pair<ParamsRaw::Result, int32_t> get_param_int(const std::string &name);
+
+    ParamsRaw::Result set_param_int(const std::string &name, int32_t value);
+
+    std::pair<ParamsRaw::Result, float> get_param_float(const std::string &name);
+
+    ParamsRaw::Result set_param_float(const std::string &name, float value);
+
+private:
+};
+
+} // namespace dronecode_sdk

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -568,9 +568,9 @@ Telemetry::FlightMode TelemetryImpl::to_flight_mode_from_custom_mode(uint32_t cu
     }
 }
 
-void TelemetryImpl::receive_param_cal_gyro(bool success, int value)
+void TelemetryImpl::receive_param_cal_gyro(MAVLinkParameters::Result result, int value)
 {
-    if (!success) {
+    if (result != MAVLinkParameters::Result::SUCCESS) {
         LogErr() << "Error: Param for gyro cal failed.";
         return;
     }
@@ -579,9 +579,9 @@ void TelemetryImpl::receive_param_cal_gyro(bool success, int value)
     set_health_gyrometer_calibration(ok);
 }
 
-void TelemetryImpl::receive_param_cal_accel(bool success, int value)
+void TelemetryImpl::receive_param_cal_accel(MAVLinkParameters::Result result, int value)
 {
-    if (!success) {
+    if (result != MAVLinkParameters::Result::SUCCESS) {
         LogErr() << "Error: Param for accel cal failed.";
         return;
     }
@@ -590,9 +590,9 @@ void TelemetryImpl::receive_param_cal_accel(bool success, int value)
     set_health_accelerometer_calibration(ok);
 }
 
-void TelemetryImpl::receive_param_cal_mag(bool success, int value)
+void TelemetryImpl::receive_param_cal_mag(MAVLinkParameters::Result result, int value)
 {
-    if (!success) {
+    if (result != MAVLinkParameters::Result::SUCCESS) {
         LogErr() << "Error: Param for mag cal failed.";
         return;
     }
@@ -602,9 +602,9 @@ void TelemetryImpl::receive_param_cal_mag(bool success, int value)
 }
 
 #ifdef LEVEL_CALIBRATION
-void TelemetryImpl::receive_param_cal_level(bool success, float value)
+void TelemetryImpl::receive_param_cal_level(MAVLinkParameters::Result result, float value)
 {
-    if (!success) {
+    if (result != MAVLinkParameters::Result::SUCCESS) {
         LogErr() << "Error: Param for level cal failed.";
         return;
     }
@@ -614,9 +614,9 @@ void TelemetryImpl::receive_param_cal_level(bool success, float value)
 }
 #endif
 
-void TelemetryImpl::receive_param_hitl(bool success, int value)
+void TelemetryImpl::receive_param_hitl(MAVLinkParameters::Result result, int value)
 {
-    if (!success) {
+    if (result != MAVLinkParameters::Result::SUCCESS) {
         LogErr() << "Error: Param to determine hitl failed.";
         return;
     }

--- a/plugins/telemetry/telemetry_impl.h
+++ b/plugins/telemetry/telemetry_impl.h
@@ -115,13 +115,13 @@ private:
     void process_heartbeat(const mavlink_message_t &message);
     void process_rc_channels(const mavlink_message_t &message);
 
-    void receive_param_cal_gyro(bool success, int value);
-    void receive_param_cal_accel(bool success, int value);
-    void receive_param_cal_mag(bool success, int value);
+    void receive_param_cal_gyro(MAVLinkParameters::Result result, int value);
+    void receive_param_cal_accel(MAVLinkParameters::Result result, int value);
+    void receive_param_cal_mag(MAVLinkParameters::Result result, int value);
 #ifdef LEVEL_CALIBRATION
-    void receive_param_cal_level(bool success, float value);
+    void receive_param_cal_level(MAVLinkParameters::Result result, float value);
 #endif
-    void receive_param_hitl(bool success, int value);
+    void receive_param_hitl(MAVLinkParameters::Result result, int value);
 
     void receive_rc_channels_timeout();
 


### PR DESCRIPTION
This adds a plugin to set/get "raw" mavlink params.

This has been tested against the E90.

When setting int parameters, we get an error but the param change still works. Hopefully, this will be fixed on the Firmware side: https://github.com/PX4/Firmware/pull/10792