### PR TITLE
Fix deadlock between do_work, reveive_timeout and receive_command_ack

### DIFF
--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -132,6 +132,8 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
 
     // LogDebug() << "We got an ack: " << command_ack.command;
 
+    std::lock_guard<std::mutex> lock(_state_mutex);
+
     auto work = _work_queue.borrow_front();
     if (!work) {
         return;
@@ -144,7 +146,6 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
         return;
     }
 
-    std::lock_guard<std::mutex> lock(_state_mutex);
     switch (command_ack.result) {
         case MAV_RESULT_ACCEPTED:
             _state = State::NONE;
@@ -273,13 +274,14 @@ void MAVLinkCommands::receive_timeout()
 
 void MAVLinkCommands::do_work()
 {
+
+    std::lock_guard<std::mutex> lock(_state_mutex);
+
     auto work = _work_queue.borrow_front();
     if (!work) {
         // Nothing to do.
         return;
     }
-
-    std::lock_guard<std::mutex> lock(_state_mutex);
 
     // If the work state is none, we can start the next command.
     switch (_state) {

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -274,7 +274,6 @@ void MAVLinkCommands::receive_timeout()
 
 void MAVLinkCommands::do_work()
 {
-
     std::lock_guard<std::mutex> lock(_state_mutex);
 
     auto work = _work_queue.borrow_front();


### PR DESCRIPTION
Hello,
There was a deadlock between these three modules.
I discovered it because I had to restart the system sometimes. But I was not able to trigger the problem using the simulator, it just happened on a raspberry using uart.

The state was:
do_work(): 282: std::lock_guard<std::mutex> lock(_state_mutex);
Not possible because receive_command_ack locked _state_mutex already.
receive_command_ack():145 _work_queue.pop_front(); 
Not possible because do_work called _work_queue.borrow_front() locking the queue.
pop_front() calls return_front() which unlocks the mutex, however, this seams not to work because the mutex is locked by an other process.
