### PR TITLE
calibration: state should be initialized to NONE

### DIFF
--- a/plugins/calibration/calibration_impl.h
+++ b/plugins/calibration/calibration_impl.h
@@ -73,7 +73,7 @@ private:
         ACCELEROMETER_CALIBRATION,
         MAGNETOMETER_CALIBRATION,
         GIMBAL_ACCELEROMETER_CALIBRATION
-    } _state;
+    } _state = State::NONE;
 
     Calibration::calibration_callback_t _calibration_callback{nullptr};
 };


### PR DESCRIPTION
Without that, the plugin may get stuck in a BUSY state.