### PR TITLE
Improve locked queue deadlocks

### DIFF
--- a/core/locked_queue.h
+++ b/core/locked_queue.h
@@ -25,65 +25,33 @@ public:
 
     class Guard {
     public:
-        Guard(std::mutex &mutex, std::deque<std::shared_ptr<T>> &queue) :
-            _mutex(mutex),
-            _queue(queue)
+        Guard(LockedQueue &locked_queue) : _locked_queue(locked_queue)
         {
-            _mutex.lock();
+            _locked_queue._mutex.lock();
         }
 
-        // With some compilers (e.g. MSVC 2017 for the debug build)
-        // the return value optimization does not trigger and the move
-        // constructor is called when Guard is returned in guard().
-        // This means that the old object is destructed while the member
-        // data is passed on to the new object. Since we are unlocking
-        // in the destructor, we need to prevent this from happening for
-        // the object which is discarded after the move constructor.
-        // This is achieved using the _invalidated flag.
+        ~Guard() { _locked_queue._mutex.unlock(); }
+
         Guard(Guard &other) = delete;
         Guard(const Guard &other) = delete;
+        Guard(Guard &&other) = delete;
+        Guard(const Guard &&other) = delete;
         Guard &operator=(const Guard &other) = delete;
         Guard &operator=(Guard &&other) = delete;
 
-        Guard(Guard &&other) : _mutex(other._mutex), _queue(other._queue)
-        {
-            other._invalidated = true;
-        }
-
-        Guard(const Guard &&other) : _mutex(other._mutex), _queue(other._queue)
-        {
-            other._invalidated = true;
-        }
-
-        ~Guard()
-        {
-            if (_invalidated) {
-                return;
-            }
-            _mutex.unlock();
-        }
-
         std::shared_ptr<T> get_front()
         {
-            if (_queue.size() == 0) {
+            if (_locked_queue._queue.size() == 0) {
                 return nullptr;
             }
-            return _queue.front();
+            return _locked_queue._queue.front();
         }
 
-        void pop_front() { _queue.pop_front(); }
+        void pop_front() { _locked_queue._queue.pop_front(); }
 
     private:
-        std::mutex &_mutex;
-        std::deque<std::shared_ptr<T>> &_queue;
-        bool _invalidated{false};
+        LockedQueue<T> &_locked_queue;
     };
-
-    Guard guard()
-    {
-        Guard new_guard{_mutex, _queue};
-        return new_guard;
-    }
 
 private:
     std::deque<std::shared_ptr<T>> _queue{};

--- a/core/locked_queue.h
+++ b/core/locked_queue.h
@@ -17,29 +17,6 @@ public:
         _queue.push_back(std::make_shared<T>(item));
     }
 
-    // This allows to get access to the front and keep others
-    // from using it. This blocks if the front is already borrowed.
-    std::shared_ptr<T> borrow_front()
-    {
-        _mutex.lock();
-        // Should not be possible because _mutex.lock()
-        if (_queue.size() == 0) {
-            // We couldn't borrow anything, therefore don't keep the lock.
-            _mutex.unlock();
-            return nullptr;
-        }
-        return _queue.front();
-    }
-
-    // This allows to return a borrowed queue.
-    void return_front() { _mutex.unlock(); }
-
-    void pop_front()
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        _queue.pop_front();
-    }
-
     size_t size()
     {
         std::lock_guard<std::mutex> lock(_mutex);

--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -21,13 +21,12 @@ TEST(LockedQueue, FillAndEmpty)
     locked_queue.push_back(three);
     EXPECT_EQ(locked_queue.size(), 3);
 
+    auto tmp = locked_queue.borrow_front();
     locked_queue.pop_front();
     EXPECT_EQ(locked_queue.size(), 2);
+    tmp = locked_queue.borrow_front();
     locked_queue.pop_front();
-    locked_queue.pop_front();
-    EXPECT_EQ(locked_queue.size(), 0);
-
-    // Popping an empty queue should just fail silently.
+    tmp = locked_queue.borrow_front();
     locked_queue.pop_front();
     EXPECT_EQ(locked_queue.size(), 0);
 }
@@ -46,14 +45,10 @@ TEST(LockedQueue, BorrowAndReturn)
 
     auto borrowed_item = locked_queue.borrow_front();
     EXPECT_EQ(*borrowed_item, 1);
-    locked_queue.return_front();
     locked_queue.pop_front();
 
     borrowed_item = locked_queue.borrow_front();
     EXPECT_EQ(*borrowed_item, 2);
-    locked_queue.return_front();
-    // Double returning shouldn't matter.
-    locked_queue.return_front();
     locked_queue.pop_front();
 
     borrowed_item = locked_queue.borrow_front();

--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -22,14 +22,14 @@ TEST(LockedQueue, FillAndEmpty)
     EXPECT_EQ(locked_queue.size(), 3);
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<int>::Guard guard(locked_queue);
         guard.pop_front();
     }
 
     EXPECT_EQ(locked_queue.size(), 2);
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<int>::Guard guard(locked_queue);
         guard.pop_front();
         guard.pop_front();
     }
@@ -50,24 +50,24 @@ TEST(LockedQueue, GuardAndReturn)
     locked_queue.push_back(three);
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<int>::Guard guard(locked_queue);
         EXPECT_EQ(*guard.get_front(), 1);
     }
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<int>::Guard guard(locked_queue);
         EXPECT_EQ(*guard.get_front(), 1);
         guard.pop_front();
     }
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<int>::Guard guard(locked_queue);
         EXPECT_EQ(*guard.get_front(), 2);
     }
 
     EXPECT_EQ(locked_queue.size(), 2);
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<int>::Guard guard(locked_queue);
         guard.pop_front();
         guard.pop_front();
         EXPECT_EQ(guard.get_front(), nullptr);
@@ -88,13 +88,14 @@ TEST(LockedQueue, ConcurrantAccess)
     auto fut = prom.get_future();
 
     {
-        auto *guard_ptr = new LockedQueue<int>::Guard(locked_queue.guard());
+        LockedQueue<int>::Guard *guard_ptr = new LockedQueue<int>::Guard(locked_queue);
+
         EXPECT_EQ(*guard_ptr->get_front(), 1);
 
         auto some_future = std::async(std::launch::async, [&prom, &locked_queue]() {
             // This will wait in the lock until the first item is returned.
             {
-                auto guard_in_callback = locked_queue.guard();
+                LockedQueue<int>::Guard guard_in_callback(locked_queue);
             }
             prom.set_value();
         });
@@ -125,7 +126,7 @@ TEST(LockedQueue, ChangeValue)
     locked_queue.push_back(one);
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<Item>::Guard guard(locked_queue);
         EXPECT_EQ(guard.get_front()->value, 42);
         auto front = guard.get_front();
         if (front) {
@@ -134,7 +135,7 @@ TEST(LockedQueue, ChangeValue)
     }
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<Item>::Guard guard(locked_queue);
         EXPECT_EQ(guard.get_front()->value, 43);
     }
 }
@@ -150,18 +151,18 @@ TEST(LockedQueue, Guard)
     locked_queue.push_back(two);
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<int>::Guard guard(locked_queue);
         EXPECT_EQ(*guard.get_front(), 1);
     }
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<int>::Guard guard(locked_queue);
         EXPECT_EQ(*guard.get_front(), 1);
         guard.pop_front();
     }
 
     {
-        auto guard = locked_queue.guard();
+        LockedQueue<int>::Guard guard(locked_queue);
         EXPECT_EQ(*guard.get_front(), 2);
 
         guard.pop_front();

--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -127,7 +127,10 @@ TEST(LockedQueue, ChangeValue)
     {
         auto guard = locked_queue.guard();
         EXPECT_EQ(guard.get_front()->value, 42);
-        guard.get_front()->value = 43;
+        auto front = guard.get_front();
+        if (front) {
+            front->value = 43;
+        }
     }
 
     {

--- a/core/locked_queue_test.cpp
+++ b/core/locked_queue_test.cpp
@@ -21,7 +21,10 @@ TEST(LockedQueue, FillAndEmpty)
     locked_queue.push_back(three);
     EXPECT_EQ(locked_queue.size(), 3);
 
-    locked_queue.pop_front();
+    {
+        auto guard = locked_queue.guard();
+        guard.pop_front();
+    }
 
     EXPECT_EQ(locked_queue.size(), 2);
 

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -129,7 +129,9 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
 
     // LogDebug() << "We got an ack: " << command_ack.command;
 
-    auto work = _work_queue.borrow_front();
+    auto work_queue_guard = _work_queue.guard();
+    auto work = work_queue_guard.get_front();
+
     if (!work) {
         return;
     }
@@ -138,41 +140,40 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
         // If the command does not match with our current command, ignore it.
         LogWarn() << "Command ack " << int(command_ack.command)
                   << " not matching our current command: " << work->mavlink_command;
-        _work_queue.return_front();
         return;
     }
 
     switch (command_ack.result) {
         case MAV_RESULT_ACCEPTED:
             _parent.unregister_timeout_handler(_timeout_cookie);
-            _work_queue.pop_front();
+            work_queue_guard.pop_front();
             call_callback(work->callback, Result::SUCCESS, 1.0f);
             break;
 
         case MAV_RESULT_DENIED:
             LogWarn() << "command denied (" << work->mavlink_command << ").";
             _parent.unregister_timeout_handler(_timeout_cookie);
-            _work_queue.pop_front();
+            work_queue_guard.pop_front();
             call_callback(work->callback, Result::COMMAND_DENIED, NAN);
             break;
 
         case MAV_RESULT_UNSUPPORTED:
             LogWarn() << "command unsupported (" << work->mavlink_command << ").";
             _parent.unregister_timeout_handler(_timeout_cookie);
-            _work_queue.pop_front();
+            work_queue_guard.pop_front();
             call_callback(work->callback, Result::COMMAND_DENIED, NAN);
             break;
 
         case MAV_RESULT_TEMPORARILY_REJECTED:
             LogWarn() << "command temporarily rejected (" << work->mavlink_command << ").";
             _parent.unregister_timeout_handler(_timeout_cookie);
-            _work_queue.pop_front();
+            work_queue_guard.pop_front();
             call_callback(work->callback, Result::COMMAND_DENIED, NAN);
             break;
 
         case MAV_RESULT_FAILED:
             _parent.unregister_timeout_handler(_timeout_cookie);
-            _work_queue.pop_front();
+            work_queue_guard.pop_front();
             call_callback(work->callback, Result::COMMAND_DENIED, NAN);
             break;
 
@@ -190,7 +191,6 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
             _parent.register_timeout_handler(std::bind(&MAVLinkCommands::receive_timeout, this),
                                              work->retries_to_do * work->timeout_s,
                                              &_timeout_cookie);
-            _work_queue.return_front();
             // FIXME: We can only call callbacks with promises once, so let's not do it
             //        on IN_PROGRESS.
             // call_callback(work->callback, Result::IN_PROGRESS, command_ack.progress /
@@ -199,7 +199,6 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
 
         default:
             LogWarn() << "Received unknown ack.";
-            _work_queue.return_front();
             break;
     }
 }
@@ -207,7 +206,8 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
 void MAVLinkCommands::receive_timeout()
 {
     // If we're not waiting, we ignore this.
-    auto work = _work_queue.borrow_front();
+    auto work_queue_guard = _work_queue.guard();
+    auto work = work_queue_guard.get_front();
 
     if (!work) {
         LogErr() << "Received timeout without item in queue.";
@@ -220,7 +220,7 @@ void MAVLinkCommands::receive_timeout()
                   << work->mavlink_command << ").";
         if (!_parent.send_message(work->mavlink_message)) {
             LogErr() << "connection send error in retransmit (" << work->mavlink_command << ").";
-            _work_queue.pop_front();
+            work_queue_guard.pop_front();
             call_callback(work->callback, Result::CONNECTION_ERROR, NAN);
 
         } else {
@@ -228,14 +228,13 @@ void MAVLinkCommands::receive_timeout()
             _parent.register_timeout_handler(std::bind(&MAVLinkCommands::receive_timeout, this),
                                              work->timeout_s,
                                              &_timeout_cookie);
-            _work_queue.return_front();
         }
 
     } else {
         // We have tried retransmitting, giving up now.
         LogErr() << "Retrying failed (" << work->mavlink_command << ")";
 
-        _work_queue.pop_front();
+        work_queue_guard.pop_front();
 
         call_callback(work->callback, Result::TIMEOUT, NAN);
     }
@@ -243,7 +242,9 @@ void MAVLinkCommands::receive_timeout()
 
 void MAVLinkCommands::do_work()
 {
-    auto work = _work_queue.borrow_front();
+    auto work_queue_guard = _work_queue.guard();
+    auto work = work_queue_guard.get_front();
+
     if (!work) {
         // Nothing to do.
         return;
@@ -253,17 +254,14 @@ void MAVLinkCommands::do_work()
         // LogDebug() << "sending it the first time (" << work->mavlink_command << ")";
         if (!_parent.send_message(work->mavlink_message)) {
             LogErr() << "connection send error (" << work->mavlink_command << ")";
-            _work_queue.pop_front();
+            work_queue_guard.pop_front();
             call_callback(work->callback, Result::CONNECTION_ERROR, NAN);
         } else {
             work->already_sent = true;
             _parent.register_timeout_handler(std::bind(&MAVLinkCommands::receive_timeout, this),
                                              work->timeout_s,
                                              &_timeout_cookie);
-            _work_queue.return_front();
         }
-    } else {
-        _work_queue.return_front();
     }
 }
 

--- a/core/mavlink_commands.cpp
+++ b/core/mavlink_commands.cpp
@@ -129,7 +129,7 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
 
     // LogDebug() << "We got an ack: " << command_ack.command;
 
-    auto work_queue_guard = _work_queue.guard();
+    LockedQueue<Work>::Guard work_queue_guard(_work_queue);
     auto work = work_queue_guard.get_front();
 
     if (!work) {
@@ -206,7 +206,7 @@ void MAVLinkCommands::receive_command_ack(mavlink_message_t message)
 void MAVLinkCommands::receive_timeout()
 {
     // If we're not waiting, we ignore this.
-    auto work_queue_guard = _work_queue.guard();
+    LockedQueue<Work>::Guard work_queue_guard(_work_queue);
     auto work = work_queue_guard.get_front();
 
     if (!work) {
@@ -242,7 +242,7 @@ void MAVLinkCommands::receive_timeout()
 
 void MAVLinkCommands::do_work()
 {
-    auto work_queue_guard = _work_queue.guard();
+    LockedQueue<Work>::Guard work_queue_guard(_work_queue);
     auto work = work_queue_guard.get_front();
 
     if (!work) {

--- a/core/mavlink_commands.h
+++ b/core/mavlink_commands.h
@@ -105,13 +105,11 @@ public:
     const MAVLinkCommands &operator=(const MAVLinkCommands &) = delete;
 
 private:
-    enum class State { NONE, WAITING, IN_PROGRESS } _state{State::NONE};
-    std::mutex _state_mutex{};
-
     struct Work {
         int retries_to_do{3};
         double timeout_s{0.5};
         uint16_t mavlink_command{0};
+        bool already_sent{false};
         mavlink_message_t mavlink_message{};
         command_result_callback_t callback{};
     };

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -120,7 +120,7 @@ MAVLinkParameters::get_param(const std::string &name, ParamValue value_type, boo
 
 void MAVLinkParameters::do_work()
 {
-    auto work_queue_guard = _work_queue.guard();
+    LockedQueue<WorkItem>::Guard work_queue_guard(_work_queue);
     auto work = work_queue_guard.get_front();
 
     if (!work) {
@@ -253,7 +253,7 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t &message)
 
     // LogDebug() << "getting param value: " << param_value.param_id;
 
-    auto work_queue_guard = _work_queue.guard();
+    LockedQueue<WorkItem>::Guard work_queue_guard(_work_queue);
     auto work = work_queue_guard.get_front();
 
     if (!work) {
@@ -312,7 +312,7 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t &message
     mavlink_param_ext_value_t param_ext_value;
     mavlink_msg_param_ext_value_decode(&message, &param_ext_value);
 
-    auto work_queue_guard = _work_queue.guard();
+    LockedQueue<WorkItem>::Guard work_queue_guard(_work_queue);
     auto work = work_queue_guard.get_front();
 
     if (!work) {
@@ -362,7 +362,7 @@ void MAVLinkParameters::process_param_ext_ack(const mavlink_message_t &message)
     mavlink_param_ext_ack_t param_ext_ack;
     mavlink_msg_param_ext_ack_decode(&message, &param_ext_ack);
 
-    auto work_queue_guard = _work_queue.guard();
+    LockedQueue<WorkItem>::Guard work_queue_guard(_work_queue);
     auto work = work_queue_guard.get_front();
 
     if (!work) {
@@ -419,7 +419,7 @@ void MAVLinkParameters::process_param_ext_ack(const mavlink_message_t &message)
 
 void MAVLinkParameters::receive_timeout()
 {
-    auto work_queue_guard = _work_queue.guard();
+    LockedQueue<WorkItem>::Guard work_queue_guard(_work_queue);
     auto work = work_queue_guard.get_front();
 
     if (!work) {

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -91,7 +91,7 @@ void MAVLinkParameters::get_param_async(const std::string &name,
     }
 
     // Otherwise push work onto queue.
-    GetParamWork new_work;
+    GetParamWork new_work{};
     new_work.callback = callback;
     new_work.param_name = name;
     new_work.param_value_type = value_type;
@@ -118,132 +118,121 @@ MAVLinkParameters::get_param(const std::string &name, ParamValue value_type, boo
 
 void MAVLinkParameters::do_work()
 {
-    std::lock_guard<std::mutex> lock(_state_mutex);
-
-    if (_state != State::NONE) {
-        // If we're still busy, let's wait
-        return;
-    }
-
     auto set_param_work = _set_param_queue.borrow_front();
-    auto get_param_work = _get_param_queue.borrow_front();
 
-    if (!set_param_work && !get_param_work) {
-        return;
-    }
-
-    // There params to set which we always do first
     if (set_param_work) {
-        // We don't need get_param_work and can give it back.
-        _get_param_queue.return_front();
+        if (!set_param_work->already_requested) {
+            char param_id[PARAM_ID_LEN + 1] = {};
+            STRNCPY(param_id, set_param_work->param_name.c_str(), sizeof(param_id) - 1);
 
-        // We need to wait for this param to get sent back as confirmation.
-        _state = State::SET_PARAM_BUSY;
+            mavlink_message_t message = {};
+            if (set_param_work->extended) {
+                char param_value_buf[128] = {};
+                set_param_work->param_value.get_128_bytes(param_value_buf);
 
-        char param_id[PARAM_ID_LEN + 1] = {};
-        STRNCPY(param_id, set_param_work->param_name.c_str(), sizeof(param_id) - 1);
-
-        mavlink_message_t message = {};
-        if (set_param_work->extended) {
-            char param_value_buf[128] = {};
-            set_param_work->param_value.get_128_bytes(param_value_buf);
-
-            // FIXME: extended currently always go to the camera component
-            mavlink_msg_param_ext_set_pack(GCSClient::system_id,
+                // FIXME: extended currently always go to the camera component
+                mavlink_msg_param_ext_set_pack(
+                    GCSClient::system_id,
+                    GCSClient::component_id,
+                    &message,
+                    _parent.get_system_id(),
+                    MAV_COMP_ID_CAMERA,
+                    param_id,
+                    param_value_buf,
+                    set_param_work->param_value.get_mav_param_ext_type());
+            } else {
+                // Param set is intended for Autopilot only.
+                mavlink_msg_param_set_pack(GCSClient::system_id,
                                            GCSClient::component_id,
                                            &message,
                                            _parent.get_system_id(),
-                                           MAV_COMP_ID_CAMERA,
+                                           _parent.get_autopilot_id(),
                                            param_id,
-                                           param_value_buf,
-                                           set_param_work->param_value.get_mav_param_ext_type());
-        } else {
-            // Param set is intended for Autopilot only.
-            mavlink_msg_param_set_pack(GCSClient::system_id,
-                                       GCSClient::component_id,
-                                       &message,
-                                       _parent.get_system_id(),
-                                       _parent.get_autopilot_id(),
-                                       param_id,
-                                       set_param_work->param_value.get_4_float_bytes(),
-                                       set_param_work->param_value.get_mav_param_type());
-        }
-
-        if (!_parent.send_message(message)) {
-            LogErr() << "Error: Send message failed";
-            if (set_param_work->callback) {
-                set_param_work->callback(MAVLinkParameters::Result::CONNECTION_ERROR);
+                                           set_param_work->param_value.get_4_float_bytes(),
+                                           set_param_work->param_value.get_mav_param_type());
             }
-            _state = State::NONE;
-            _set_param_queue.pop_front();
-            return;
+
+            if (!_parent.send_message(message)) {
+                LogErr() << "Error: Send message failed";
+                if (set_param_work->callback) {
+                    set_param_work->callback(MAVLinkParameters::Result::CONNECTION_ERROR);
+                }
+                _set_param_queue.pop_front();
+                return;
+            }
+
+            set_param_work->already_requested = true;
+
+            // _last_request_time = _parent.get_time().steady_time();
+
+            // We want to get notified if a timeout happens
+            _parent.register_timeout_handler(
+                std::bind(&MAVLinkParameters::receive_timeout, this), 0.5, &_timeout_cookie);
+
+            _set_param_queue.return_front();
+        } else {
+            _set_param_queue.return_front();
         }
+    }
 
-        // _last_request_time = _parent.get_time().steady_time();
+    auto get_param_work = _get_param_queue.borrow_front();
+    if (get_param_work) {
+        if (!get_param_work->already_requested) {
+            char param_id[PARAM_ID_LEN + 1] = {};
+            STRNCPY(param_id, get_param_work->param_name.c_str(), sizeof(param_id) - 1);
 
-        // We want to get notified if a timeout happens
-        _parent.register_timeout_handler(
-            std::bind(&MAVLinkParameters::receive_timeout, this), 0.5, &_timeout_cookie);
+            // LogDebug() << "now getting: " << get_param_work->param_name;
 
-        _set_param_queue.return_front();
+            mavlink_message_t message = {};
+            if (get_param_work->extended) {
+                mavlink_msg_param_ext_request_read_pack(GCSClient::system_id,
+                                                        GCSClient::component_id,
+                                                        &message,
+                                                        _parent.get_system_id(),
+                                                        MAV_COMP_ID_CAMERA,
+                                                        param_id,
+                                                        -1);
 
-    } else {
-        _set_param_queue.return_front();
+            } else {
+                // LogDebug() << "request read: "
+                //    << (int)GCSClient::system_id << ":"
+                //    << (int)GCSClient::component_id <<
+                //    " to "
+                //    << (int)_parent.get_system_id() << ":"
+                //    << (int)_parent.get_autopilot_id();
 
-        // The busy flag gets reset when the param comes in
-        // or after a timeout.
-        _state = State::GET_PARAM_BUSY;
-
-        char param_id[PARAM_ID_LEN + 1] = {};
-        STRNCPY(param_id, get_param_work->param_name.c_str(), sizeof(param_id) - 1);
-
-        // LogDebug() << "now getting: " << get_param_work->param_name;
-
-        mavlink_message_t message = {};
-        if (get_param_work->extended) {
-            mavlink_msg_param_ext_request_read_pack(GCSClient::system_id,
+                mavlink_msg_param_request_read_pack(GCSClient::system_id,
                                                     GCSClient::component_id,
                                                     &message,
                                                     _parent.get_system_id(),
-                                                    MAV_COMP_ID_CAMERA,
+                                                    _parent.get_autopilot_id(),
                                                     param_id,
                                                     -1);
-
-        } else {
-            // LogDebug() << "request read: "
-            //    << (int)GCSClient::system_id << ":"
-            //    << (int)GCSClient::component_id <<
-            //    " to "
-            //    << (int)_parent.get_system_id() << ":"
-            //    << (int)_parent.get_autopilot_id();
-
-            mavlink_msg_param_request_read_pack(GCSClient::system_id,
-                                                GCSClient::component_id,
-                                                &message,
-                                                _parent.get_system_id(),
-                                                _parent.get_autopilot_id(),
-                                                param_id,
-                                                -1);
-        }
-
-        if (!_parent.send_message(message)) {
-            LogErr() << "Error: Send message failed";
-            if (get_param_work->callback) {
-                ParamValue empty_param;
-                get_param_work->callback(MAVLinkParameters::Result::CONNECTION_ERROR, empty_param);
             }
-            _state = State::NONE;
-            _get_param_queue.pop_front();
-            return;
+
+            if (!_parent.send_message(message)) {
+                LogErr() << "Error: Send message failed";
+                if (get_param_work->callback) {
+                    ParamValue empty_param;
+                    get_param_work->callback(MAVLinkParameters::Result::CONNECTION_ERROR,
+                                             empty_param);
+                }
+                _get_param_queue.pop_front();
+                return;
+            }
+
+            get_param_work->already_requested = true;
+
+            // _last_request_time = _parent.get_time().steady_time();
+
+            // We want to get notified if a timeout happens
+            _parent.register_timeout_handler(
+                std::bind(&MAVLinkParameters::receive_timeout, this), 0.5, &_timeout_cookie);
+
+            _get_param_queue.return_front();
+        } else {
+            _get_param_queue.return_front();
         }
-
-        // _last_request_time = _parent.get_time().steady_time();
-
-        // We want to get notified if a timeout happens
-        _parent.register_timeout_handler(
-            std::bind(&MAVLinkParameters::receive_timeout, this), 0.5, &_timeout_cookie);
-
-        _get_param_queue.return_front();
     }
 }
 
@@ -268,31 +257,26 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t &message)
 
     // LogDebug() << "getting param value: " << param_value.param_id;
 
-    std::lock_guard<std::mutex> lock(_state_mutex);
+    auto get_param_work = _get_param_queue.borrow_front();
 
-    if (_state == State::NONE) {
-        return;
-    }
-
-    if (_state == State::GET_PARAM_BUSY) {
-        auto work = _get_param_queue.borrow_front();
-        if (work) {
-            if (strncmp(work->param_name.c_str(), param_value.param_id, PARAM_ID_LEN) == 0) {
+    if (get_param_work) {
+        if (get_param_work->already_requested) {
+            if (strncmp(get_param_work->param_name.c_str(), param_value.param_id, PARAM_ID_LEN) ==
+                0) {
                 ParamValue value;
                 value.set_from_mavlink_param_value(param_value);
-                if (value.is_same_type(work->param_value_type)) {
-                    _cache[work->param_name] = value;
-                    if (work->callback) {
-                        work->callback(MAVLinkParameters::Result::SUCCESS, value);
+                if (value.is_same_type(get_param_work->param_value_type)) {
+                    _cache[get_param_work->param_name] = value;
+                    if (get_param_work->callback) {
+                        get_param_work->callback(MAVLinkParameters::Result::SUCCESS, value);
                     }
                 } else {
                     LogErr() << "Param types don't match";
                     ParamValue no_value;
-                    if (work->callback) {
-                        work->callback(MAVLinkParameters::Result::WRONG_TYPE, no_value);
+                    if (get_param_work->callback) {
+                        get_param_work->callback(MAVLinkParameters::Result::WRONG_TYPE, no_value);
                     }
                 }
-                _state = State::NONE;
                 _parent.unregister_timeout_handler(_timeout_cookie);
                 // LogDebug() << "time taken: " <<
                 // _parent.get_time().elapsed_since_s(_last_request_time);
@@ -301,21 +285,25 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t &message)
                 // No match, let's just return the borrowed work item.
                 _get_param_queue.return_front();
             }
+        } else {
+            // Nevermind, the request is not event sent yet.
+            _get_param_queue.return_front();
         }
+        return;
     }
 
-    else if (_state == State::SET_PARAM_BUSY) {
-        auto work = _set_param_queue.borrow_front();
-        if (work) {
+    auto set_param_work = _set_param_queue.borrow_front();
+    if (set_param_work) {
+        if (set_param_work->already_requested) {
             // Now it still needs to match the param name
-            if (strncmp(work->param_name.c_str(), param_value.param_id, PARAM_ID_LEN) == 0) {
+            if (strncmp(set_param_work->param_name.c_str(), param_value.param_id, PARAM_ID_LEN) ==
+                0) {
                 // We are done, inform caller and go back to idle
-                _cache[work->param_name] = work->param_value;
-                if (work->callback) {
-                    work->callback(MAVLinkParameters::Result::SUCCESS);
+                _cache[set_param_work->param_name] = set_param_work->param_value;
+                if (set_param_work->callback) {
+                    set_param_work->callback(MAVLinkParameters::Result::SUCCESS);
                 }
 
-                _state = State::NONE;
                 _parent.unregister_timeout_handler(_timeout_cookie);
                 // LogDebug() << "time taken: " <<
                 // _parent.get_time().elapsed_since_s(_last_request_time);
@@ -323,7 +311,11 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t &message)
             } else {
                 _set_param_queue.return_front();
             }
+        } else {
+            // Nevermind, the request is not event sent yet.
+            _set_param_queue.return_front();
         }
+        return;
     }
 }
 
@@ -333,31 +325,27 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t &message
     mavlink_param_ext_value_t param_ext_value;
     mavlink_msg_param_ext_value_decode(&message, &param_ext_value);
 
-    std::lock_guard<std::mutex> lock(_state_mutex);
+    auto get_param_work = _get_param_queue.borrow_front();
 
-    if (_state == State::NONE) {
-        return;
-    }
-
-    if (_state == State::GET_PARAM_BUSY) {
-        auto work = _get_param_queue.borrow_front();
-        if (work) {
-            if (strncmp(work->param_name.c_str(), param_ext_value.param_id, PARAM_ID_LEN) == 0) {
+    if (get_param_work) {
+        if (get_param_work->already_requested) {
+            if (strncmp(get_param_work->param_name.c_str(),
+                        param_ext_value.param_id,
+                        PARAM_ID_LEN) == 0) {
                 ParamValue value;
                 value.set_from_mavlink_param_ext_value(param_ext_value);
-                if (value.is_same_type(work->param_value_type)) {
-                    _cache[work->param_name] = value;
-                    if (work->callback) {
-                        work->callback(MAVLinkParameters::Result::SUCCESS, value);
+                if (value.is_same_type(get_param_work->param_value_type)) {
+                    _cache[get_param_work->param_name] = value;
+                    if (get_param_work->callback) {
+                        get_param_work->callback(MAVLinkParameters::Result::SUCCESS, value);
                     }
                 } else {
                     LogErr() << "Param types don't match";
                     ParamValue no_value;
-                    if (work->callback) {
-                        work->callback(MAVLinkParameters::Result::WRONG_TYPE, no_value);
+                    if (get_param_work->callback) {
+                        get_param_work->callback(MAVLinkParameters::Result::WRONG_TYPE, no_value);
                     }
                 }
-                _state = State::NONE;
                 _parent.unregister_timeout_handler(_timeout_cookie);
                 // LogDebug() << "time taken: " <<
                 // _parent.get_time().elapsed_since_s(_last_request_time);
@@ -365,33 +353,10 @@ void MAVLinkParameters::process_param_ext_value(const mavlink_message_t &message
             } else {
                 _get_param_queue.return_front();
             }
+        } else {
+            _get_param_queue.return_front();
         }
     }
-
-#if 0
-    else if (_state == State::SET_PARAM_BUSY) {
-
-        auto work = _set_param_queue.borrow_front();
-        if (work) {
-            // Now it still needs to match the param name
-            if (strncmp(work->param_name.c_str(), param_ext_value.param_id, PARAM_ID_LEN) == 0) {
-
-                // We are done, inform caller and go back to idle
-                _cache[work->param_name] = work->param_value;
-                if (work->callback) {
-                    work->callback(MAVLinkParameters::Result::SUCCESS);
-                }
-
-                _state = State::NONE;
-                _parent.unregister_timeout_handler(_timeout_cookie);
-                // LogDebug() << "time taken: " << _parent.get_time().elapsed_since_s(_last_request_time);
-                _set_param_queue.pop_front();
-            } else {
-                _set_param_queue.return_front();
-            }
-        }
-    }
-#endif
 }
 
 void MAVLinkParameters::process_param_ext_ack(const mavlink_message_t &message)
@@ -401,47 +366,44 @@ void MAVLinkParameters::process_param_ext_ack(const mavlink_message_t &message)
     mavlink_param_ext_ack_t param_ext_ack;
     mavlink_msg_param_ext_ack_decode(&message, &param_ext_ack);
 
-    std::lock_guard<std::mutex> lock(_state_mutex);
+    auto set_param_work = _set_param_queue.borrow_front();
+    if (set_param_work) {
+        if (set_param_work->already_requested) {
+            // Now it still needs to match the param name
+            if (strncmp(set_param_work->param_name.c_str(), param_ext_ack.param_id, PARAM_ID_LEN) ==
+                0) {
+                if (param_ext_ack.param_result == PARAM_ACK_ACCEPTED) {
+                    // We are done, inform caller and go back to idle
+                    _cache[set_param_work->param_name] = set_param_work->param_value;
+                    if (set_param_work->callback) {
+                        set_param_work->callback(MAVLinkParameters::Result::SUCCESS);
+                    }
 
-    if (_state != State::SET_PARAM_BUSY) {
-        return;
-    }
+                    _parent.unregister_timeout_handler(_timeout_cookie);
+                    // LogDebug() << "time taken: " <<
+                    // _parent.get_time().elapsed_since_s(_last_request_time);
+                    _set_param_queue.pop_front();
 
-    auto work = _set_param_queue.borrow_front();
-    if (work) {
-        // Now it still needs to match the param name
-        if (strncmp(work->param_name.c_str(), param_ext_ack.param_id, PARAM_ID_LEN) == 0) {
-            if (param_ext_ack.param_result == PARAM_ACK_ACCEPTED) {
-                // We are done, inform caller and go back to idle
-                _cache[work->param_name] = work->param_value;
-                if (work->callback) {
-                    work->callback(MAVLinkParameters::Result::SUCCESS);
+                } else if (param_ext_ack.param_result == PARAM_ACK_IN_PROGRESS) {
+                    // Reset timeout and wait again.
+                    _parent.refresh_timeout_handler(_timeout_cookie);
+                    _set_param_queue.return_front();
+
+                } else {
+                    LogErr() << "Somehow we did not get an ack, we got: "
+                             << int(param_ext_ack.param_result);
+
+                    if (set_param_work->callback) {
+                        set_param_work->callback(MAVLinkParameters::Result::TIMEOUT);
+                    }
+
+                    _parent.unregister_timeout_handler(_timeout_cookie);
+                    // LogDebug() << "time taken: " <<
+                    // _parent.get_time().elapsed_since_s(_last_request_time);
+                    _set_param_queue.pop_front();
                 }
-
-                _state = State::NONE;
-                _parent.unregister_timeout_handler(_timeout_cookie);
-                // LogDebug() << "time taken: " <<
-                // _parent.get_time().elapsed_since_s(_last_request_time);
-                _set_param_queue.pop_front();
-
-            } else if (param_ext_ack.param_result == PARAM_ACK_IN_PROGRESS) {
-                // Reset timeout and wait again.
-                _parent.refresh_timeout_handler(_timeout_cookie);
-                _set_param_queue.return_front();
-
             } else {
-                LogErr() << "Somehow we did not get an ack, we got: "
-                         << int(param_ext_ack.param_result);
-
-                if (work->callback) {
-                    work->callback(MAVLinkParameters::Result::TIMEOUT);
-                }
-
-                _state = State::NONE;
-                _parent.unregister_timeout_handler(_timeout_cookie);
-                // LogDebug() << "time taken: " <<
-                // _parent.get_time().elapsed_since_s(_last_request_time);
-                _set_param_queue.pop_front();
+                _set_param_queue.return_front();
             }
         } else {
             _set_param_queue.return_front();
@@ -451,43 +413,38 @@ void MAVLinkParameters::process_param_ext_ack(const mavlink_message_t &message)
 
 void MAVLinkParameters::receive_timeout()
 {
-    std::lock_guard<std::mutex> lock(_state_mutex);
-
-    if (_state == State::NONE) {
-        // Strange, a timeout even though we're not doing anything
-        return;
-    }
-
-    if (_state == State::GET_PARAM_BUSY) {
-        auto work = _get_param_queue.borrow_front();
-        if (work) {
-            if (work->callback) {
+    auto get_param_work = _get_param_queue.borrow_front();
+    if (get_param_work) {
+        if (get_param_work->already_requested) {
+            if (get_param_work->callback) {
                 ParamValue empty_value;
                 // Notify about timeout
-                LogErr() << "Error: get param busy timeout: " << work->param_name;
+                LogErr() << "Error: get param busy timeout: " << get_param_work->param_name;
                 // LogErr() << "Got it after: " <<
                 // _parent.get_time().elapsed_since_s(_last_request_time);
-                work->callback(MAVLinkParameters::Result::TIMEOUT, empty_value);
+                get_param_work->callback(MAVLinkParameters::Result::TIMEOUT, empty_value);
             }
-            _state = State::NONE;
+            // TODO: we should retry!
             _get_param_queue.pop_front();
+        } else {
+            _get_param_queue.return_front();
         }
     }
 
-    else if (_state == State::SET_PARAM_BUSY) {
-        // This means work has been going on that we should try again
-        if (_set_param_queue.size() > 0) {
-            auto work = _set_param_queue.borrow_front();
-
-            if (work->callback) {
+    auto set_param_work = _set_param_queue.borrow_front();
+    if (set_param_work) {
+        if (set_param_work->already_requested) {
+            if (set_param_work->callback) {
                 // Notify about timeout
-                LogErr() << "Error: set param busy timeout: " << work->param_name;
+                LogErr() << "Error: set param busy timeout: " << set_param_work->param_name;
                 // LogErr() << "Got it after: " <<
                 // _parent.get_time().elapsed_since_s(_last_request_time);
-                work->callback(MAVLinkParameters::Result::TIMEOUT);
+                set_param_work->callback(MAVLinkParameters::Result::TIMEOUT);
             }
-            _state = State::NONE;
+            // TODO: we should retry!
             _set_param_queue.pop_front();
+        } else {
+            _set_param_queue.return_front();
         }
     }
 }

--- a/core/mavlink_parameters.cpp
+++ b/core/mavlink_parameters.cpp
@@ -46,13 +46,14 @@ void MAVLinkParameters::set_param_async(const std::string &name,
         return;
     }
 
-    SetParamWork new_work;
-    new_work.callback = callback;
+    WorkItem new_work{};
+    new_work.type = WorkItem::Type::Set;
+    new_work.set_param_callback = callback;
     new_work.param_name = name;
     new_work.param_value = value;
     new_work.extended = extended;
 
-    _set_param_queue.push_back(new_work);
+    _work_queue.push_back(new_work);
 }
 
 MAVLinkParameters::Result
@@ -91,13 +92,14 @@ void MAVLinkParameters::get_param_async(const std::string &name,
     }
 
     // Otherwise push work onto queue.
-    GetParamWork new_work{};
-    new_work.callback = callback;
+    WorkItem new_work{};
+    new_work.type = WorkItem::Type::Get;
+    new_work.get_param_callback = callback;
     new_work.param_name = name;
-    new_work.param_value_type = value_type;
+    new_work.param_value = value_type;
     new_work.extended = extended;
 
-    _get_param_queue.push_back(new_work);
+    _work_queue.push_back(new_work);
 }
 
 std::pair<MAVLinkParameters::Result, MAVLinkParameters::ParamValue>
@@ -118,28 +120,37 @@ MAVLinkParameters::get_param(const std::string &name, ParamValue value_type, boo
 
 void MAVLinkParameters::do_work()
 {
-    auto set_param_work = _set_param_queue.borrow_front();
+    auto work = _work_queue.borrow_front();
 
-    if (set_param_work) {
-        if (!set_param_work->already_requested) {
-            char param_id[PARAM_ID_LEN + 1] = {};
-            STRNCPY(param_id, set_param_work->param_name.c_str(), sizeof(param_id) - 1);
+    if (!work) {
+        return;
+    }
 
-            mavlink_message_t message = {};
-            if (set_param_work->extended) {
+    if (work->already_requested) {
+        _work_queue.return_front();
+        return;
+    }
+
+    char param_id[PARAM_ID_LEN + 1] = {};
+    STRNCPY(param_id, work->param_name.c_str(), sizeof(param_id) - 1);
+
+    mavlink_message_t message{};
+
+    switch (work->type) {
+        case WorkItem::Type::Set: {
+            if (work->extended) {
                 char param_value_buf[128] = {};
-                set_param_work->param_value.get_128_bytes(param_value_buf);
+                work->param_value.get_128_bytes(param_value_buf);
 
                 // FIXME: extended currently always go to the camera component
-                mavlink_msg_param_ext_set_pack(
-                    GCSClient::system_id,
-                    GCSClient::component_id,
-                    &message,
-                    _parent.get_system_id(),
-                    MAV_COMP_ID_CAMERA,
-                    param_id,
-                    param_value_buf,
-                    set_param_work->param_value.get_mav_param_ext_type());
+                mavlink_msg_param_ext_set_pack(GCSClient::system_id,
+                                               GCSClient::component_id,
+                                               &message,
+                                               _parent.get_system_id(),
+                                               MAV_COMP_ID_CAMERA,
+                                               param_id,
+                                               param_value_buf,
+                                               work->param_value.get_mav_param_ext_type());
             } else {
                 // Param set is intended for Autopilot only.
                 mavlink_msg_param_set_pack(GCSClient::system_id,
@@ -148,43 +159,32 @@ void MAVLinkParameters::do_work()
                                            _parent.get_system_id(),
                                            _parent.get_autopilot_id(),
                                            param_id,
-                                           set_param_work->param_value.get_4_float_bytes(),
-                                           set_param_work->param_value.get_mav_param_type());
+                                           work->param_value.get_4_float_bytes(),
+                                           work->param_value.get_mav_param_type());
             }
 
             if (!_parent.send_message(message)) {
                 LogErr() << "Error: Send message failed";
-                if (set_param_work->callback) {
-                    set_param_work->callback(MAVLinkParameters::Result::CONNECTION_ERROR);
+                if (work->set_param_callback) {
+                    work->set_param_callback(MAVLinkParameters::Result::CONNECTION_ERROR);
                 }
-                _set_param_queue.pop_front();
+                _work_queue.pop_front();
                 return;
             }
 
-            set_param_work->already_requested = true;
-
+            work->already_requested = true;
             // _last_request_time = _parent.get_time().steady_time();
 
             // We want to get notified if a timeout happens
             _parent.register_timeout_handler(
                 std::bind(&MAVLinkParameters::receive_timeout, this), 0.5, &_timeout_cookie);
 
-            _set_param_queue.return_front();
-        } else {
-            _set_param_queue.return_front();
-        }
-    }
+            _work_queue.return_front();
+        } break;
 
-    auto get_param_work = _get_param_queue.borrow_front();
-    if (get_param_work) {
-        if (!get_param_work->already_requested) {
-            char param_id[PARAM_ID_LEN + 1] = {};
-            STRNCPY(param_id, get_param_work->param_name.c_str(), sizeof(param_id) - 1);
-
-            // LogDebug() << "now getting: " << get_param_work->param_name;
-
-            mavlink_message_t message = {};
-            if (get_param_work->extended) {
+        case WorkItem::Type::Get: {
+            // LogDebug() << "now getting: " << work->param_name;
+            if (work->extended) {
                 mavlink_msg_param_ext_request_read_pack(GCSClient::system_id,
                                                         GCSClient::component_id,
                                                         &message,
@@ -212,16 +212,16 @@ void MAVLinkParameters::do_work()
 
             if (!_parent.send_message(message)) {
                 LogErr() << "Error: Send message failed";
-                if (get_param_work->callback) {
+                if (work->get_param_callback) {
                     ParamValue empty_param;
-                    get_param_work->callback(MAVLinkParameters::Result::CONNECTION_ERROR,
+                    work->get_param_callback(MAVLinkParameters::Result::CONNECTION_ERROR,
                                              empty_param);
                 }
-                _get_param_queue.pop_front();
+                _work_queue.pop_front();
                 return;
             }
 
-            get_param_work->already_requested = true;
+            work->already_requested = true;
 
             // _last_request_time = _parent.get_time().steady_time();
 
@@ -229,10 +229,8 @@ void MAVLinkParameters::do_work()
             _parent.register_timeout_handler(
                 std::bind(&MAVLinkParameters::receive_timeout, this), 0.5, &_timeout_cookie);
 
-            _get_param_queue.return_front();
-        } else {
-            _get_param_queue.return_front();
-        }
+            _work_queue.return_front();
+        } break;
     }
 }
 
@@ -257,105 +255,108 @@ void MAVLinkParameters::process_param_value(const mavlink_message_t &message)
 
     // LogDebug() << "getting param value: " << param_value.param_id;
 
-    auto get_param_work = _get_param_queue.borrow_front();
+    auto work = _work_queue.borrow_front();
 
-    if (get_param_work) {
-        if (get_param_work->already_requested) {
-            if (strncmp(get_param_work->param_name.c_str(), param_value.param_id, PARAM_ID_LEN) ==
-                0) {
-                ParamValue value;
-                value.set_from_mavlink_param_value(param_value);
-                if (value.is_same_type(get_param_work->param_value_type)) {
-                    _cache[get_param_work->param_name] = value;
-                    if (get_param_work->callback) {
-                        get_param_work->callback(MAVLinkParameters::Result::SUCCESS, value);
-                    }
-                } else {
-                    LogErr() << "Param types don't match";
-                    ParamValue no_value;
-                    if (get_param_work->callback) {
-                        get_param_work->callback(MAVLinkParameters::Result::WRONG_TYPE, no_value);
-                    }
-                }
-                _parent.unregister_timeout_handler(_timeout_cookie);
-                // LogDebug() << "time taken: " <<
-                // _parent.get_time().elapsed_since_s(_last_request_time);
-                _get_param_queue.pop_front();
-            } else {
-                // No match, let's just return the borrowed work item.
-                _get_param_queue.return_front();
-            }
-        } else {
-            // Nevermind, the request is not event sent yet.
-            _get_param_queue.return_front();
-        }
+    if (!work) {
         return;
     }
 
-    auto set_param_work = _set_param_queue.borrow_front();
-    if (set_param_work) {
-        if (set_param_work->already_requested) {
-            // Now it still needs to match the param name
-            if (strncmp(set_param_work->param_name.c_str(), param_value.param_id, PARAM_ID_LEN) ==
-                0) {
-                // We are done, inform caller and go back to idle
-                _cache[set_param_work->param_name] = set_param_work->param_value;
-                if (set_param_work->callback) {
-                    set_param_work->callback(MAVLinkParameters::Result::SUCCESS);
-                }
-
-                _parent.unregister_timeout_handler(_timeout_cookie);
-                // LogDebug() << "time taken: " <<
-                // _parent.get_time().elapsed_since_s(_last_request_time);
-                _set_param_queue.pop_front();
-            } else {
-                _set_param_queue.return_front();
-            }
-        } else {
-            // Nevermind, the request is not event sent yet.
-            _set_param_queue.return_front();
-        }
+    if (!work->already_requested) {
+        _work_queue.return_front();
         return;
+    }
+
+    if (strncmp(work->param_name.c_str(), param_value.param_id, PARAM_ID_LEN) != 0) {
+        // No match, let's just return the borrowed work item.
+        _work_queue.return_front();
+        return;
+    }
+
+    switch (work->type) {
+        case WorkItem::Type::Get: {
+            ParamValue value;
+            value.set_from_mavlink_param_value(param_value);
+            if (value.is_same_type(work->param_value)) {
+                _cache[work->param_name] = value;
+                if (work->get_param_callback) {
+                    work->get_param_callback(MAVLinkParameters::Result::SUCCESS, value);
+                }
+            } else {
+                LogErr() << "Param types don't match";
+                ParamValue no_value;
+                if (work->get_param_callback) {
+                    work->get_param_callback(MAVLinkParameters::Result::WRONG_TYPE, no_value);
+                }
+            }
+            _parent.unregister_timeout_handler(_timeout_cookie);
+            // LogDebug() << "time taken: " <<
+            // _parent.get_time().elapsed_since_s(_last_request_time);
+            _work_queue.pop_front();
+        } break;
+        case WorkItem::Type::Set: {
+            // We are done, inform caller and go back to idle
+            _cache[work->param_name] = work->param_value;
+            if (work->set_param_callback) {
+                work->set_param_callback(MAVLinkParameters::Result::SUCCESS);
+            }
+
+            _parent.unregister_timeout_handler(_timeout_cookie);
+            // LogDebug() << "time taken: " <<
+            // _parent.get_time().elapsed_since_s(_last_request_time);
+            _work_queue.pop_front();
+        } break;
     }
 }
 
 void MAVLinkParameters::process_param_ext_value(const mavlink_message_t &message)
 {
     // LogDebug() << "getting param ext value";
+
     mavlink_param_ext_value_t param_ext_value;
     mavlink_msg_param_ext_value_decode(&message, &param_ext_value);
 
-    auto get_param_work = _get_param_queue.borrow_front();
+    auto work = _work_queue.borrow_front();
 
-    if (get_param_work) {
-        if (get_param_work->already_requested) {
-            if (strncmp(get_param_work->param_name.c_str(),
-                        param_ext_value.param_id,
-                        PARAM_ID_LEN) == 0) {
-                ParamValue value;
-                value.set_from_mavlink_param_ext_value(param_ext_value);
-                if (value.is_same_type(get_param_work->param_value_type)) {
-                    _cache[get_param_work->param_name] = value;
-                    if (get_param_work->callback) {
-                        get_param_work->callback(MAVLinkParameters::Result::SUCCESS, value);
-                    }
-                } else {
-                    LogErr() << "Param types don't match";
-                    ParamValue no_value;
-                    if (get_param_work->callback) {
-                        get_param_work->callback(MAVLinkParameters::Result::WRONG_TYPE, no_value);
-                    }
+    if (!work) {
+        return;
+    }
+
+    if (!work->already_requested) {
+        _work_queue.return_front();
+        return;
+    }
+
+    if (strncmp(work->param_name.c_str(), param_ext_value.param_id, PARAM_ID_LEN) != 0) {
+        _work_queue.return_front();
+        return;
+    }
+
+    switch (work->type) {
+        case WorkItem::Type::Get: {
+            ParamValue value;
+            value.set_from_mavlink_param_ext_value(param_ext_value);
+            if (value.is_same_type(work->param_value)) {
+                _cache[work->param_name] = value;
+                if (work->get_param_callback) {
+                    work->get_param_callback(MAVLinkParameters::Result::SUCCESS, value);
                 }
-                _parent.unregister_timeout_handler(_timeout_cookie);
-                // LogDebug() << "time taken: " <<
-                // _parent.get_time().elapsed_since_s(_last_request_time);
-                _get_param_queue.pop_front();
             } else {
-                _get_param_queue.return_front();
+                LogErr() << "Param types don't match";
+                ParamValue no_value;
+                if (work->get_param_callback) {
+                    work->get_param_callback(MAVLinkParameters::Result::WRONG_TYPE, no_value);
+                }
             }
-        } else {
-            _get_param_queue.return_front();
-        }
+            _parent.unregister_timeout_handler(_timeout_cookie);
+            // LogDebug() << "time taken: " <<
+            // _parent.get_time().elapsed_since_s(_last_request_time);
+            _work_queue.pop_front();
+        } break;
+
+        case WorkItem::Type::Set:
+            LogWarn() << "Unexpected ParamExtValue response";
+            _work_queue.return_front();
+            break;
     }
 }
 
@@ -366,86 +367,102 @@ void MAVLinkParameters::process_param_ext_ack(const mavlink_message_t &message)
     mavlink_param_ext_ack_t param_ext_ack;
     mavlink_msg_param_ext_ack_decode(&message, &param_ext_ack);
 
-    auto set_param_work = _set_param_queue.borrow_front();
-    if (set_param_work) {
-        if (set_param_work->already_requested) {
-            // Now it still needs to match the param name
-            if (strncmp(set_param_work->param_name.c_str(), param_ext_ack.param_id, PARAM_ID_LEN) ==
-                0) {
-                if (param_ext_ack.param_result == PARAM_ACK_ACCEPTED) {
-                    // We are done, inform caller and go back to idle
-                    _cache[set_param_work->param_name] = set_param_work->param_value;
-                    if (set_param_work->callback) {
-                        set_param_work->callback(MAVLinkParameters::Result::SUCCESS);
-                    }
+    auto work = _work_queue.borrow_front();
 
-                    _parent.unregister_timeout_handler(_timeout_cookie);
-                    // LogDebug() << "time taken: " <<
-                    // _parent.get_time().elapsed_since_s(_last_request_time);
-                    _set_param_queue.pop_front();
+    if (!work) {
+        return;
+    }
 
-                } else if (param_ext_ack.param_result == PARAM_ACK_IN_PROGRESS) {
-                    // Reset timeout and wait again.
-                    _parent.refresh_timeout_handler(_timeout_cookie);
-                    _set_param_queue.return_front();
+    if (!work->already_requested) {
+        _work_queue.return_front();
+        return;
+    }
 
-                } else {
-                    LogErr() << "Somehow we did not get an ack, we got: "
-                             << int(param_ext_ack.param_result);
+    // Now it still needs to match the param name
+    if (strncmp(work->param_name.c_str(), param_ext_ack.param_id, PARAM_ID_LEN) == 0) {
+        _work_queue.return_front();
+        return;
+    }
 
-                    if (set_param_work->callback) {
-                        set_param_work->callback(MAVLinkParameters::Result::TIMEOUT);
-                    }
+    switch (work->type) {
+        case WorkItem::Type::Get: {
+            LogWarn() << "Unexpected ParamExtAck response.";
+            _work_queue.return_front();
+        } break;
 
-                    _parent.unregister_timeout_handler(_timeout_cookie);
-                    // LogDebug() << "time taken: " <<
-                    // _parent.get_time().elapsed_since_s(_last_request_time);
-                    _set_param_queue.pop_front();
+        case WorkItem::Type::Set: {
+            if (param_ext_ack.param_result == PARAM_ACK_ACCEPTED) {
+                // We are done, inform caller and go back to idle
+                _cache[work->param_name] = work->param_value;
+                if (work->set_param_callback) {
+                    work->set_param_callback(MAVLinkParameters::Result::SUCCESS);
                 }
+
+                _parent.unregister_timeout_handler(_timeout_cookie);
+                // LogDebug() << "time taken: " <<
+                // _parent.get_time().elapsed_since_s(_last_request_time);
+                _work_queue.pop_front();
+
+            } else if (param_ext_ack.param_result == PARAM_ACK_IN_PROGRESS) {
+                // Reset timeout and wait again.
+                _parent.refresh_timeout_handler(_timeout_cookie);
+                _work_queue.return_front();
+
             } else {
-                _set_param_queue.return_front();
+                LogErr() << "Somehow we did not get an ack, we got: "
+                         << int(param_ext_ack.param_result);
+
+                if (work->set_param_callback) {
+                    work->set_param_callback(MAVLinkParameters::Result::TIMEOUT);
+                }
+
+                _parent.unregister_timeout_handler(_timeout_cookie);
+                // LogDebug() << "time taken: " <<
+                // _parent.get_time().elapsed_since_s(_last_request_time);
+                _work_queue.pop_front();
             }
-        } else {
-            _set_param_queue.return_front();
-        }
+        } break;
     }
 }
 
 void MAVLinkParameters::receive_timeout()
 {
-    auto get_param_work = _get_param_queue.borrow_front();
-    if (get_param_work) {
-        if (get_param_work->already_requested) {
-            if (get_param_work->callback) {
-                ParamValue empty_value;
-                // Notify about timeout
-                LogErr() << "Error: get param busy timeout: " << get_param_work->param_name;
-                // LogErr() << "Got it after: " <<
-                // _parent.get_time().elapsed_since_s(_last_request_time);
-                get_param_work->callback(MAVLinkParameters::Result::TIMEOUT, empty_value);
-            }
-            // TODO: we should retry!
-            _get_param_queue.pop_front();
-        } else {
-            _get_param_queue.return_front();
-        }
+    auto work = _work_queue.borrow_front();
+
+    if (!work) {
+        LogErr() << "Received timeout without work";
+        return;
     }
 
-    auto set_param_work = _set_param_queue.borrow_front();
-    if (set_param_work) {
-        if (set_param_work->already_requested) {
-            if (set_param_work->callback) {
+    if (!work->already_requested) {
+        _work_queue.return_front();
+        return;
+    }
+
+    switch (work->type) {
+        case WorkItem::Type::Get: {
+            if (work->get_param_callback) {
+                ParamValue empty_value;
                 // Notify about timeout
-                LogErr() << "Error: set param busy timeout: " << set_param_work->param_name;
+                LogErr() << "Error: get param busy timeout: " << work->param_name;
                 // LogErr() << "Got it after: " <<
                 // _parent.get_time().elapsed_since_s(_last_request_time);
-                set_param_work->callback(MAVLinkParameters::Result::TIMEOUT);
+                work->get_param_callback(MAVLinkParameters::Result::TIMEOUT, empty_value);
             }
             // TODO: we should retry!
-            _set_param_queue.pop_front();
-        } else {
-            _set_param_queue.return_front();
-        }
+            _work_queue.pop_front();
+        } break;
+        case WorkItem::Type::Set: {
+            if (work->set_param_callback) {
+                // Notify about timeout
+                LogErr() << "Error: set param busy timeout: " << work->param_name;
+                // LogErr() << "Got it after: " <<
+                // _parent.get_time().elapsed_since_s(_last_request_time);
+                work->set_param_callback(MAVLinkParameters::Result::TIMEOUT);
+            }
+            // TODO: we should retry!
+            _work_queue.pop_front();
+        } break;
     }
 }
 

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -511,26 +511,18 @@ private:
     // Params can be up to 16 chars without 0-termination.
     static constexpr size_t PARAM_ID_LEN = 16;
 
-    struct SetParamWork {
-        set_param_callback_t callback = nullptr;
+    struct WorkItem {
+        enum class Type { Get, Set } type{Type::Get};
+        // TODO: a union would be nicer for the callback
+        get_param_callback_t get_param_callback{nullptr};
+        set_param_callback_t set_param_callback{nullptr};
         std::string param_name{};
         ParamValue param_value{};
-        bool extended = false;
-        int retries_done = 0;
+        bool extended{false};
+        int retries_done{0};
         bool already_requested{false};
     };
-
-    LockedQueue<SetParamWork> _set_param_queue{};
-
-    struct GetParamWork {
-        get_param_callback_t callback = nullptr;
-        std::string param_name{};
-        ParamValue param_value_type{};
-        bool extended = false;
-        int retries_done = 0;
-        bool already_requested{false};
-    };
-    LockedQueue<GetParamWork> _get_param_queue{};
+    LockedQueue<WorkItem> _work_queue{};
 
     std::map<std::string, ParamValue> _cache{};
 

--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -508,9 +508,6 @@ private:
 
     SystemImpl &_parent;
 
-    enum class State { NONE, SET_PARAM_BUSY, GET_PARAM_BUSY } _state = State::NONE;
-    std::mutex _state_mutex{};
-
     // Params can be up to 16 chars without 0-termination.
     static constexpr size_t PARAM_ID_LEN = 16;
 
@@ -520,6 +517,7 @@ private:
         ParamValue param_value{};
         bool extended = false;
         int retries_done = 0;
+        bool already_requested{false};
     };
 
     LockedQueue<SetParamWork> _set_param_queue{};
@@ -530,6 +528,7 @@ private:
         ParamValue param_value_type{};
         bool extended = false;
         int retries_done = 0;
+        bool already_requested{false};
     };
     LockedQueue<GetParamWork> _get_param_queue{};
 

--- a/integration_tests/params_raw.cpp
+++ b/integration_tests/params_raw.cpp
@@ -93,8 +93,6 @@ TEST_F(SitlTest, ParamsRawHappy)
 
         // Get initial value.
         ASSERT_EQ(get_result1.first, ParamsRaw::Result::SUCCESS);
-        ASSERT_GE(get_result1.second, 0);
-        ASSERT_LE(get_result1.second, 1);
 
         std::this_thread::sleep_for(std::chrono::seconds(1));
 

--- a/integration_tests/params_raw.cpp
+++ b/integration_tests/params_raw.cpp
@@ -28,7 +28,7 @@ TEST_F(SitlTest, ParamsRawSad)
 
     {
         const std::pair<ParamsRaw::Result, int32_t> get_result =
-            params_raw->get_param_int("COM_RC_LOSS_MAN");
+            params_raw->get_param_int("MPC_VEL_MANUAL");
         EXPECT_EQ(get_result.first, ParamsRaw::Result::WRONG_TYPE);
     }
 
@@ -89,7 +89,7 @@ TEST_F(SitlTest, ParamsRawHappy)
 
     {
         const std::pair<ParamsRaw::Result, float> get_result1 =
-            params_raw->get_param_float("COM_RC_LOSS_MAN");
+            params_raw->get_param_float("MPC_VEL_MANUAL");
 
         // Get initial value.
         ASSERT_EQ(get_result1.first, ParamsRaw::Result::SUCCESS);
@@ -100,12 +100,12 @@ TEST_F(SitlTest, ParamsRawHappy)
 
         // Toggle the value.
         const ParamsRaw::Result set_result1 =
-            params_raw->set_param_float("COM_RC_LOSS_MAN", get_result1.second + 1.0f);
+            params_raw->set_param_float("MPC_VEL_MANUAL", get_result1.second + 1.0f);
         EXPECT_EQ(set_result1, ParamsRaw::Result::SUCCESS);
 
         // Verify toggle.
         const std::pair<ParamsRaw::Result, float> get_result2 =
-            params_raw->get_param_float("COM_RC_LOSS_MAN");
+            params_raw->get_param_float("MPC_VEL_MANUAL");
         EXPECT_EQ(get_result2.first, ParamsRaw::Result::SUCCESS);
         EXPECT_FLOAT_EQ(get_result2.second, get_result1.second + 1.0f);
 
@@ -113,12 +113,12 @@ TEST_F(SitlTest, ParamsRawHappy)
 
         // Reset back to initial value.
         const ParamsRaw::Result set_result2 =
-            params_raw->set_param_float("COM_RC_LOSS_MAN", get_result1.second);
+            params_raw->set_param_float("MPC_VEL_MANUAL", get_result1.second);
         EXPECT_EQ(set_result2, ParamsRaw::Result::SUCCESS);
 
         // Verify reset.
         const std::pair<ParamsRaw::Result, float> get_result3 =
-            params_raw->get_param_float("COM_RC_LOSS_MAN");
+            params_raw->get_param_float("MPC_VEL_MANUAL");
         EXPECT_EQ(get_result3.first, ParamsRaw::Result::SUCCESS);
         EXPECT_FLOAT_EQ(get_result3.second, get_result1.second);
     }


### PR DESCRIPTION
This is a further attempt following #590 to prevent potential deadlocks.

- [x] mavlink_commands: remove state variable and mutex.
- [x] mavlink_parameters: remove state variable and mutex.
- [x] locked_queue: avoid re-locking on pop (always require borrow first).