### PR TITLE
Add calibration cancel (replaces #624)

### DIFF
--- a/plugins/calibration/calibration.cpp
+++ b/plugins/calibration/calibration.cpp
@@ -31,6 +31,11 @@ void Calibration::calibrate_gimbal_accelerometer_async(calibration_callback_t ca
     _impl->calibrate_gimbal_accelerometer_async(callback);
 }
 
+void Calibration::cancel_calibration()
+{
+    _impl->cancel_calibration();
+}
+
 const char *Calibration::result_str(Result result)
 {
     switch (result) {

--- a/plugins/calibration/calibration_impl.h
+++ b/plugins/calibration/calibration_impl.h
@@ -24,6 +24,8 @@ public:
     void calibrate_magnetometer_async(const Calibration::calibration_callback_t &callback);
     void calibrate_gimbal_accelerometer_async(const Calibration::calibration_callback_t &callback);
 
+    void cancel_calibration();
+
 private:
     void call_user_callback(const Calibration::calibration_callback_t &callback,
                             const Calibration::Result &result,

--- a/plugins/calibration/include/plugins/calibration/calibration.h
+++ b/plugins/calibration/include/plugins/calibration/calibration.h
@@ -123,6 +123,12 @@ public:
     void calibrate_gimbal_accelerometer_async(calibration_callback_t callback);
 
     /**
+     * @brief Cancel ongoing calibration.
+     *
+     */
+    void cancel_calibration();
+
+    /**
      * @brief Copy constructor (object is not copyable).
      */
     Calibration(const Calibration &) = delete;


### PR DESCRIPTION
This adds a method to cancel an ongoing calibration.