### PR TITLE
build: add include to fix build for Alpine Linux

### DIFF
--- a/core/serial_connection.cpp
+++ b/core/serial_connection.cpp
@@ -5,6 +5,7 @@
 #if defined(LINUX)
 #include <unistd.h>
 #include <fcntl.h>
+#include <asm/ioctls.h>
 #include <asm/termbits.h>
 #include <sys/ioctl.h>
 


### PR DESCRIPTION
Required for TCGETS2/TCSETS2 when building on Alpine Linux.