### PR TITLE
info: expose new UUID (uid2)

### DIFF
--- a/integration_tests/info.cpp
+++ b/integration_tests/info.cpp
@@ -65,6 +65,23 @@ TEST_F(SitlTest, Info)
             LogWarn() << "Product request result: " << Info::result_str(product_result.first);
         }
 
+        std::pair<Info::Result, Info::Identification> identification_result =
+            info->get_identification();
+
+        EXPECT_EQ(identification_result.first, Info::Result::SUCCESS);
+
+        if (identification_result.first == Info::Result::SUCCESS) {
+            std::cout << "Hardware UUID: " << identification_result.second.hardware_uuid;
+            for (unsigned j = 0; j < sizeof(identification_result.second.hardware_uuid); ++j) {
+                std::cout << std::hex << std::setfill('0') << std::setw(2)
+                          << int(identification_result.second.hardware_uuid[j]);
+            }
+            std::cout << std::endl;
+        } else {
+            LogWarn() << "Identification request result: "
+                      << Info::result_str(identification_result.first);
+        }
+
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 }

--- a/integration_tests/info.cpp
+++ b/integration_tests/info.cpp
@@ -71,10 +71,10 @@ TEST_F(SitlTest, Info)
         EXPECT_EQ(identification_result.first, Info::Result::SUCCESS);
 
         if (identification_result.first == Info::Result::SUCCESS) {
-            std::cout << "Hardware UUID: " << identification_result.second.hardware_uuid;
-            for (unsigned j = 0; j < sizeof(identification_result.second.hardware_uuid); ++j) {
+            std::cout << "Hardware UID: " << identification_result.second.hardware_uid;
+            for (unsigned j = 0; j < sizeof(identification_result.second.hardware_uid); ++j) {
                 std::cout << std::hex << std::setfill('0') << std::setw(2)
-                          << int(identification_result.second.hardware_uuid[j]);
+                          << int(identification_result.second.hardware_uid[j]);
             }
             std::cout << std::endl;
         } else {

--- a/plugins/info/include/plugins/info/info.h
+++ b/plugins/info/include/plugins/info/info.h
@@ -82,14 +82,21 @@ public:
     };
 
     /**
+     * @brief Type containing identification.
+     */
+    struct Identification {
+        uint8_t hardware_uuid[18]; /**< @brief UUID of hardware. */
+    };
+
+    /**
      * @brief Gets the UUID of the system.
      *
      * If possible this will be a unique identifier provided by hardware.
      *
      * @return a pair containing the result of the request and if successful,
-     * the UUID of the system.
+     * the identification information of the system.
      */
-    std::pair<Result, uint64_t> uuid() const;
+    std::pair<Result, Identification> get_identification() const;
 
     /**
      * @brief Get system version information.

--- a/plugins/info/include/plugins/info/info.h
+++ b/plugins/info/include/plugins/info/info.h
@@ -85,7 +85,7 @@ public:
      * @brief Type containing identification.
      */
     struct Identification {
-        uint8_t hardware_uuid[18]; /**< @brief UUID of hardware. */
+        uint8_t hardware_uid[18]; /**< @brief UID of hardware. */
     };
 
     /**

--- a/plugins/info/include/plugins/info/info.h
+++ b/plugins/info/include/plugins/info/info.h
@@ -85,7 +85,8 @@ public:
      * @brief Type containing identification.
      */
     struct Identification {
-        uint8_t hardware_uid[18]; /**< @brief UID of hardware. */
+        uint8_t hardware_uid[18]; /**< @brief UID of hardware. This refers to uid2 of MAVLink. If
+                                     the system does not support uid2 yet, this will be all zero. */
     };
 
     /**

--- a/plugins/info/include/plugins/info/info.h
+++ b/plugins/info/include/plugins/info/info.h
@@ -90,7 +90,7 @@ public:
     };
 
     /**
-     * @brief Gets the UUID of the system.
+     * @brief Gets the identification of the system.
      *
      * If possible this will be a unique identifier provided by hardware.
      *

--- a/plugins/info/info.cpp
+++ b/plugins/info/info.cpp
@@ -7,9 +7,9 @@ Info::Info(System &system) : PluginBase(), _impl{new InfoImpl(system)} {}
 
 Info::~Info() {}
 
-std::pair<Info::Result, uint64_t> Info::uuid() const
+std::pair<Info::Result, Info::Identification> Info::get_identification() const
 {
-    return _impl->get_uuid();
+    return _impl->get_identification();
 }
 
 std::pair<Info::Result, Info::Version> Info::get_version() const

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -117,7 +117,8 @@ void InfoImpl::process_autopilot_version(const mavlink_message_t &message)
     const char *product_name = product_id_str(autopilot_version.product_id);
     STRNCPY(_product.product_name, product_name, sizeof(_product.product_name) - 1);
 
-    static_assert(sizeof(_identification.hardware_uid) == sizeof(autopilot_version.uid2));
+    static_assert(sizeof(_identification.hardware_uid) == sizeof(autopilot_version.uid2),
+                  "UID length mismatch");
     std::memcpy(
         _identification.hardware_uid, autopilot_version.uid2, sizeof(autopilot_version.uid2));
 

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -118,27 +118,10 @@ void InfoImpl::process_autopilot_version(const mavlink_message_t &message)
     STRNCPY(_product.product_name, product_name, sizeof(_product.product_name) - 1);
 
     std::memset(_identification.hardware_uid, 0, sizeof(_identification.hardware_uid));
-
-    if (is_array_zero(autopilot_version.uid2, sizeof(autopilot_version.uid2))) {
-        std::memcpy(_identification.hardware_uid,
-                    reinterpret_cast<uint8_t *>(&autopilot_version.uid),
-                    sizeof(autopilot_version.uid));
-    } else {
-        std::memcpy(
-            _identification.hardware_uid, autopilot_version.uid2, sizeof(autopilot_version.uid2));
-    }
+    std::memcpy(
+        _identification.hardware_uid, autopilot_version.uid2, sizeof(autopilot_version.uid2));
 
     _information_received = true;
-}
-
-bool InfoImpl::is_array_zero(const uint8_t *arr, size_t len)
-{
-    for (size_t i = 0; i < len; ++i) {
-        if (arr[i] != 0) {
-            return false;
-        }
-    }
-    return true;
 }
 
 void InfoImpl::translate_binary_to_str(uint8_t *binary,

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -117,15 +117,15 @@ void InfoImpl::process_autopilot_version(const mavlink_message_t &message)
     const char *product_name = product_id_str(autopilot_version.product_id);
     STRNCPY(_product.product_name, product_name, sizeof(_product.product_name) - 1);
 
-    std::memset(_identification.hardware_uuid, 0, sizeof(_identification.hardware_uuid));
+    std::memset(_identification.hardware_uid, 0, sizeof(_identification.hardware_uid));
 
     if (is_array_zero(autopilot_version.uid2, sizeof(autopilot_version.uid2))) {
-        std::memcpy(_identification.hardware_uuid,
+        std::memcpy(_identification.hardware_uid,
                     reinterpret_cast<uint8_t *>(&autopilot_version.uid),
                     sizeof(autopilot_version.uid));
     } else {
         std::memcpy(
-            _identification.hardware_uuid, autopilot_version.uid2, sizeof(autopilot_version.uid2));
+            _identification.hardware_uid, autopilot_version.uid2, sizeof(autopilot_version.uid2));
     }
 
     _information_received = true;

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -117,6 +117,8 @@ void InfoImpl::process_autopilot_version(const mavlink_message_t &message)
     const char *product_name = product_id_str(autopilot_version.product_id);
     STRNCPY(_product.product_name, product_name, sizeof(_product.product_name) - 1);
 
+    std::memset(_identification.hardware_uuid, 0, sizeof(_identification.hardware_uuid));
+
     if (is_array_zero(autopilot_version.uid2, sizeof(autopilot_version.uid2))) {
         std::memcpy(_identification.hardware_uuid,
                     reinterpret_cast<uint8_t *>(&autopilot_version.uid),

--- a/plugins/info/info_impl.cpp
+++ b/plugins/info/info_impl.cpp
@@ -117,7 +117,7 @@ void InfoImpl::process_autopilot_version(const mavlink_message_t &message)
     const char *product_name = product_id_str(autopilot_version.product_id);
     STRNCPY(_product.product_name, product_name, sizeof(_product.product_name) - 1);
 
-    std::memset(_identification.hardware_uid, 0, sizeof(_identification.hardware_uid));
+    static_assert(sizeof(_identification.hardware_uid) == sizeof(autopilot_version.uid2));
     std::memcpy(
         _identification.hardware_uid, autopilot_version.uid2, sizeof(autopilot_version.uid2));
 

--- a/plugins/info/info_impl.h
+++ b/plugins/info/info_impl.h
@@ -18,7 +18,7 @@ public:
     void enable() override;
     void disable() override;
 
-    std::pair<Info::Result, uint64_t> get_uuid() const;
+    std::pair<Info::Result, Info::Identification> get_identification() const;
     std::pair<Info::Result, Info::Version> get_version() const;
     std::pair<Info::Result, Info::Product> get_product() const;
 
@@ -34,6 +34,7 @@ private:
 
     Info::Version _version{};
     Info::Product _product{};
+    Info::Identification _identification{};
     bool _information_received{false};
 
     void *_call_every_cookie{nullptr};
@@ -43,6 +44,8 @@ private:
 
     static void
     translate_binary_to_str(uint8_t *binary, unsigned binary_len, char *str, unsigned str_len);
+
+    static bool is_array_zero(const uint8_t *arr, size_t len);
 };
 
 } // namespace dronecode_sdk

--- a/plugins/info/info_impl.h
+++ b/plugins/info/info_impl.h
@@ -44,8 +44,6 @@ private:
 
     static void
     translate_binary_to_str(uint8_t *binary, unsigned binary_len, char *str, unsigned str_len);
-
-    static bool is_array_zero(const uint8_t *arr, size_t len);
 };
 
 } // namespace dronecode_sdk


### PR DESCRIPTION
This adds support to query the new UUID using the info plugin.
Vehicles only sending the old UUID (uid) are still supported if the uid2 is all zeros as specified.

@bkueng or @thomasetter please review.