### PR TITLE
Fix interpretation of MAVLink landed enum

### DIFF
--- a/plugins/action/action_impl.cpp
+++ b/plugins/action/action_impl.cpp
@@ -422,7 +422,9 @@ void ActionImpl::process_extended_sys_state(const mavlink_message_t &message)
 {
     mavlink_extended_sys_state_t extended_sys_state;
     mavlink_msg_extended_sys_state_decode(&message, &extended_sys_state);
-    if (extended_sys_state.landed_state == MAV_LANDED_STATE_IN_AIR) {
+    if (extended_sys_state.landed_state == MAV_LANDED_STATE_IN_AIR ||
+        extended_sys_state.landed_state == MAV_LANDED_STATE_TAKEOFF ||
+        extended_sys_state.landed_state == MAV_LANDED_STATE_LANDING) {
         _in_air = true;
     } else if (extended_sys_state.landed_state == MAV_LANDED_STATE_ON_GROUND) {
         _in_air = false;

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -427,7 +427,9 @@ void TelemetryImpl::process_extended_sys_state(const mavlink_message_t &message)
     mavlink_extended_sys_state_t extended_sys_state;
     mavlink_msg_extended_sys_state_decode(&message, &extended_sys_state);
 
-    if (extended_sys_state.landed_state == MAV_LANDED_STATE_IN_AIR) {
+    if (extended_sys_state.landed_state == MAV_LANDED_STATE_IN_AIR ||
+        extended_sys_state.landed_state == MAV_LANDED_STATE_TAKEOFF ||
+        extended_sys_state.landed_state == MAV_LANDED_STATE_LANDING) {
         set_in_air(true);
     } else if (extended_sys_state.landed_state == MAV_LANDED_STATE_ON_GROUND) {
         set_in_air(false);


### PR DESCRIPTION
Previously, the states TAKEOFF and LANDING would be translated to whatever the previous landed state had been. This lead to the fact that we would call disarm in some integration tests when the vehicle was still flying.

This is related to:
https://github.com/mavlink/mavlink/pull/698