### PR TITLE
Remove Fedora 27 CI build and add Fedora 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,13 @@ matrix:
       services:
         - docker
       env:
-      - MATRIX_EVAL="BUILD_TARGET=docker_build_fedora_27"
+      - MATRIX_EVAL="BUILD_TARGET=docker_build_fedora_28"
     - os: linux
       sudo: true
       services:
         - docker
       env:
-      - MATRIX_EVAL="BUILD_TARGET=docker_build_fedora_28"
+      - MATRIX_EVAL="BUILD_TARGET=docker_build_fedora_29"
     - os: osx
       osx_image: xcode9.3
       env:
@@ -84,11 +84,11 @@ install:
 - if [[ "${BUILD_TARGET}" = "docker_build_ubuntu_18.04" ]]; then
     docker pull dronecode/dronecode-sdk-ubuntu-18.04;
   fi
-- if [[ "${BUILD_TARGET}" = "docker_build_fedora_27" ]]; then
-    docker pull dronecode/dronecode-sdk-fedora-27;
-  fi
 - if [[ "${BUILD_TARGET}" = "docker_build_fedora_28" ]]; then
     docker pull dronecode/dronecode-sdk-fedora-28;
+  fi
+- if [[ "${BUILD_TARGET}" = "docker_build_fedora_29" ]]; then
+    docker pull dronecode/dronecode-sdk-fedora-29;
   fi
 - if [[ "${BUILD_TARGET}" = "coverage_build" ]]; then
     pip install --user cpp-coveralls;
@@ -112,13 +112,13 @@ script:
     docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-ubuntu-18.04 ./travis-docker-build.sh;
     docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-ubuntu-18.04 ./create_packages.sh;
   fi
-- if [[ "${BUILD_TARGET}" = "docker_build_fedora_27" ]]; then
-    docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-27 ./travis-docker-build.sh;
-    docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-27 ./create_packages.sh;
-  fi
 - if [[ "${BUILD_TARGET}" = "docker_build_fedora_28" ]]; then
     docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-28 ./travis-docker-build.sh;
     docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-28 ./create_packages.sh;
+  fi
+- if [[ "${BUILD_TARGET}" = "docker_build_fedora_29" ]]; then
+    docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-29 ./travis-docker-build.sh;
+    docker run -it --rm -v $TRAVIS_BUILD_DIR:/home/user/DronecodeSDK:rw -e LOCAL_USER_ID=`id -u` dronecode/dronecode-sdk-fedora-29 ./create_packages.sh;
   fi
 - if [[ "${BUILD_TARGET}" = "osx_build" ]]; then
     make;

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         stage('Ubuntu 16.04 Debug') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-ubuntu-16.04:2018-11-28'
+              image 'dronecode/dronecode-sdk-ubuntu-16.04:2019-01-18'
               args '-e LOCAL_USER_ID=user_id'
             }
           }
@@ -35,7 +35,7 @@ pipeline {
         stage('Ubuntu 16.04 Release') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-ubuntu-16.04:2018-11-28'
+              image 'dronecode/dronecode-sdk-ubuntu-16.04:2019-01-18'
             }
           }
           steps {
@@ -52,7 +52,7 @@ pipeline {
         stage('Ubuntu 18.04 Debug') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-ubuntu-18.04:2018-11-28'
+              image 'dronecode/dronecode-sdk-ubuntu-18.04:2019-01-18'
             }
           }
           steps {
@@ -69,7 +69,7 @@ pipeline {
         stage('Ubuntu 18.04 Release') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-ubuntu-18.04:2018-11-28'
+              image 'dronecode/dronecode-sdk-ubuntu-18.04:2019-01-18'
             }
           }
           steps {
@@ -86,7 +86,7 @@ pipeline {
         stage('Fedora 27 Debug') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-fedora-27:2018-11-28'
+              image 'dronecode/dronecode-sdk-fedora-28:2019-01-18'
             }
           }
           steps {
@@ -103,7 +103,7 @@ pipeline {
         stage('Fedora 27 Release') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-fedora-27:2018-11-28'
+              image 'dronecode/dronecode-sdk-fedora-28:2019-01-18'
             }
           }
           steps {
@@ -120,7 +120,7 @@ pipeline {
         stage('Fedora 28 Debug') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-fedora-28:2018-11-28'
+              image 'dronecode/dronecode-sdk-fedora-29:2019-01-18'
             }
           }
           steps {
@@ -137,7 +137,7 @@ pipeline {
         stage('Fedora 28 Release') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-fedora-28:2018-11-28'
+              image 'dronecode/dronecode-sdk-fedora-29:2019-01-18'
             }
           }
           steps {
@@ -160,7 +160,7 @@ pipeline {
         stage('check style') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-ubuntu-16.04:2018-11-28'
+              image 'dronecode/dronecode-sdk-ubuntu-16.04:2019-01-18'
             }
           }
           steps {
@@ -171,7 +171,7 @@ pipeline {
         stage('example/takeoff_land') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-ubuntu-16.04:2018-11-28'
+              image 'dronecode/dronecode-sdk-ubuntu-16.04:2019-01-18'
             }
           }
           steps {
@@ -187,7 +187,7 @@ pipeline {
         stage('example/fly_mission') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-ubuntu-16.04:2018-11-28'
+              image 'dronecode/dronecode-sdk-ubuntu-16.04:2019-01-18'
             }
           }
           steps {
@@ -203,7 +203,7 @@ pipeline {
         stage('example/offboard_velocity') {
           agent {
             docker {
-              image 'dronecode/dronecode-sdk-ubuntu-16.04:2018-11-28'
+              image 'dronecode/dronecode-sdk-ubuntu-16.04:2019-01-18'
             }
           }
           steps {
@@ -222,7 +222,7 @@ pipeline {
     stage('Generate Docs') {
       agent {
         docker {
-          image 'dronecode/dronecode-sdk-ubuntu-16.04:2018-11-28'
+          image 'dronecode/dronecode-sdk-ubuntu-16.04:2019-01-18'
         }
       }
       steps {

--- a/docker/Dockerfile-Fedora-29
+++ b/docker/Dockerfile-Fedora-29
@@ -1,10 +1,10 @@
 #
-# Development environment for the Dronecode SDK based on Fedora 27.
+# Development environment for the Dronecode SDK based on Fedora 29.
 #
 # Author: Julian Oes <julian@oes.ch>
 #
 
-FROM fedora:27
+FROM fedora:29
 
 MAINTAINER Julian Oes <julian@oes.ch>
 
@@ -20,23 +20,18 @@ RUN dnf -y install \
     git \
     libcurl-devel \
     libtool \
+    make \
     python \
     tinyxml2-devel \
     redhat-rpm-config \
     rpm-build \
     ruby-devel \
     rubygems \
-    wget \
     which \
     zlib-devel \
     golang \
     sudo \
     && dnf clean all
-
-RUN wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-Fedora27.tar.xz \
-    && tar xvfJ clang+llvm-6.0.0-x86_64-linux-gnu-Fedora27.tar.xz \
-    && cp clang+llvm-6.0.0-x86_64-linux-gnu-Fedora27/bin/clang-format /usr/local/bin/ \
-    && rm -rf clang+llvm-6.0.0-x86_64-linux-gnu-Fedora27.tar.xz clang+llvm-6.0.0-x86_64-linux-gnu-Fedora27
 
 RUN gem install --no-ri --no-rdoc fpm;
 

--- a/docker/build_and_push_docker_images.sh
+++ b/docker/build_and_push_docker_images.sh
@@ -2,27 +2,27 @@
 
 set -e
 
-docker pull dronecode/dronecode-sdk-fedora-27
 docker pull dronecode/dronecode-sdk-fedora-28
+docker pull dronecode/dronecode-sdk-fedora-29
 docker pull dronecode/dronecode-sdk-ubuntu-16.04
 docker pull dronecode/dronecode-sdk-ubuntu-18.04
 
-docker build -f Dockerfile-Fedora-27 -t dronecode/dronecode-sdk-fedora-27 .
 docker build -f Dockerfile-Fedora-28 -t dronecode/dronecode-sdk-fedora-28 .
+docker build -f Dockerfile-Fedora-29 -t dronecode/dronecode-sdk-fedora-29 .
 docker build -f Dockerfile-Ubuntu-16.04 -t dronecode/dronecode-sdk-ubuntu-16.04 .
 docker build -f Dockerfile-Ubuntu-18.04 -t dronecode/dronecode-sdk-ubuntu-18.04 .
 
 DATE=`date +%Y-%m-%d`
 
-docker tag dronecode/dronecode-sdk-fedora-27:latest dronecode/dronecode-sdk-fedora-27:$DATE
 docker tag dronecode/dronecode-sdk-fedora-28:latest dronecode/dronecode-sdk-fedora-28:$DATE
+docker tag dronecode/dronecode-sdk-fedora-29:latest dronecode/dronecode-sdk-fedora-29:$DATE
 docker tag dronecode/dronecode-sdk-ubuntu-16.04:latest dronecode/dronecode-sdk-ubuntu-16.04:$DATE
 docker tag dronecode/dronecode-sdk-ubuntu-18.04:latest dronecode/dronecode-sdk-ubuntu-18.04:$DATE
 
-docker push dronecode/dronecode-sdk-fedora-27:latest
-docker push dronecode/dronecode-sdk-fedora-27:$DATE
 docker push dronecode/dronecode-sdk-fedora-28:latest
 docker push dronecode/dronecode-sdk-fedora-28:$DATE
+docker push dronecode/dronecode-sdk-fedora-29:latest
+docker push dronecode/dronecode-sdk-fedora-29:$DATE
 docker push dronecode/dronecode-sdk-ubuntu-16.04:latest
 docker push dronecode/dronecode-sdk-ubuntu-16.04:$DATE
 docker push dronecode/dronecode-sdk-ubuntu-18.04:latest


### PR DESCRIPTION
Fedora 27 has already been end-of-lifed last year, so we should remove it and add Fedora 28 instead.