### PR TITLE
cmake: remove the 'v' at the beginning of version tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ set(dronecode_sdk_install_include_dir "include/dronecode_sdk")
 set(dronecode_sdk_install_lib_dir ${lib_path})
 
 execute_process(
-    COMMAND git describe --abbrev=8 --dirty --always --tags
+    COMMAND git describe --abbrev=8 --dirty --always --tags | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*.*$\)/\1/'
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE VERSION_STR
     OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
So that tags like v0.14.0 become 0.14.0 and are valid for Info.plist