### PR TITLE
mavlink_passthrough: reset intercepting messages

### DIFF
--- a/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
+++ b/plugins/mavlink_passthrough/mavlink_passthrough_impl.cpp
@@ -17,7 +17,11 @@ MavlinkPassthroughImpl::~MavlinkPassthroughImpl()
 
 void MavlinkPassthroughImpl::init() {}
 
-void MavlinkPassthroughImpl::deinit() {}
+void MavlinkPassthroughImpl::deinit()
+{
+    _parent->intercept_incoming_messages(nullptr);
+    _parent->intercept_outgoing_messages(nullptr);
+}
 
 void MavlinkPassthroughImpl::enable() {}
 


### PR DESCRIPTION
When being destructed we should stop to intercept all the messages.