### PR TITLE
Plugins: don't remove pending timeouts on disconnect

### DIFF
--- a/plugins/mission/mission_impl.cpp
+++ b/plugins/mission/mission_impl.cpp
@@ -58,13 +58,11 @@ void MissionImpl::init()
 
 void MissionImpl::enable() {}
 
-void MissionImpl::disable()
-{
-    _parent->unregister_timeout_handler(_timeout_cookie);
-}
+void MissionImpl::disable() {}
 
 void MissionImpl::deinit()
 {
+    _parent->unregister_timeout_handler(_timeout_cookie);
     _parent->unregister_all_mavlink_message_handlers(this);
 }
 

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -70,6 +70,7 @@ void TelemetryImpl::init()
 
 void TelemetryImpl::deinit()
 {
+    _parent->unregister_timeout_handler(_timeout_cookie);
     _parent->unregister_param_changed_handler(this);
     _parent->unregister_all_mavlink_message_handlers(this);
 }
@@ -118,10 +119,7 @@ void TelemetryImpl::enable()
                                            std::placeholders::_2));
 }
 
-void TelemetryImpl::disable()
-{
-    _parent->unregister_timeout_handler(_timeout_cookie);
-}
+void TelemetryImpl::disable() {}
 
 Telemetry::Result TelemetryImpl::set_rate_position_velocity_ned(double rate_hz)
 {


### PR DESCRIPTION
We  should not get rid of pending timeouts just because the system is reported to be timed out which can happen if we miss a couple of heartbeats in a row due to a lossy connection. We still want to get the notification that our current transaction timed out, otherwise we'll wait for an answer indefinitely (unless the user of the API checks for a timeout again which shouldn't be required).

Found as part of https://github.com/Auterion/mavlink-testing-suite/pull/10.