### PR TITLE
[WIP] Docker backend service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# docker
+docker/
+# build & install folders
+build*/
+install/
+logs/
+.vscode
+# auto-generated files (below) from Qt Creator
+*.config
+*.creator*
+*.files
+*.includes
+CMakeLists.txt.user*
+
+.DS_Store

--- a/docker/Dockerfile-backend
+++ b/docker/Dockerfile-backend
@@ -1,0 +1,20 @@
+#
+# Build the DronecodeSDK and launches the backend bin
+#
+# Author: Ramón Roche <julian@oes.ch>
+#
+
+FROM dronecode/dronecode-sdk-base:latest
+MAINTAINER Ramón Roche <mrpollo@gmail.com>
+
+ENV BUILD_BACKEND 1
+WORKDIR "/home/user/DronecodeSDK"
+ADD [".", "/home/user/DronecodeSDK"]
+
+# ADD can sometimes copy build/
+# lets make sure we have a clean build
+RUN mkdir build \
+	&& make clean
+RUN make default
+CMD ./build/default/backend/src/backend_bin
+

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -1,0 +1,37 @@
+#
+# Development environment for the Dronecode SDK based on Ubuntu 18.04.
+#
+# Author: Ramón Roche <mrpollo@gmail.com>
+#
+
+FROM alpine:3.9
+MAINTAINER Ramón Roche <mrpollo@gmail.com>
+
+ENV \
+	DEBIAN_FRONTEND noninteractive \
+	TERM xterm-color
+
+RUN apk --no-cache update \
+	&& apk upgrade \
+	&& apk --no-cache add --update --virtual build-dependencies \
+		astyle \
+		automake \
+		build-base \
+		ca-certificates \
+		cmake \
+		colordiff \
+		curl-dev \
+		doxygen \
+		gcc \
+		g++ \
+		git \
+		libc6-compat \
+		libstdc++ \
+		libtool \
+		make \
+		openssl \
+		openssl-dev \
+		tinyxml2-dev \
+		zlib-dev \
+	&& rm -rf /var/cache/apk/*
+


### PR DESCRIPTION
This PR adds two new Docker images, the intention is to create a **backend_bin** service container, an older version of this backend container is being used by a new experimental js client for web apps, running the backend next to sitl and a proxy translating http1 to grpc as shown here [docker-compose.yml](https://github.com/mrpollo/DronecodeSDK-JavaScript/blob/master/docker/docker-compose.yml).

New images

| Image | Description | Size |
| --- | --- | --- |
| `dronecode-sdk-base` | based on alpine, minimal deps for SDK build, small image size | 287MB |
| `dronecode-sdk-backend` | based on sdk-base builds and launches the backend | ??? |

TODO
- [ ] Build grpc on alpine
- [ ] Build DronecodeSDK on alpine
- [ ] Publish on docker hub

Note: building the `dronecode-sdk-backend` image needs to happen on the root of the project

```bash
docker build -f docker/Dockerfile-backend -t mrpollo/dronecode-sdk-backend:latest .
```