### PR TITLE
issue#609: only send heartbeat after discovering vehicles

### DIFF
--- a/core/system_impl.cpp
+++ b/core/system_impl.cpp
@@ -304,7 +304,9 @@ void SystemImpl::system_thread()
 
     while (!_should_exit) {
         if (_time.elapsed_since_s(last_time) >= SystemImpl::_HEARTBEAT_SEND_INTERVAL_S) {
-            send_heartbeat();
+            if (_parent.is_connected()) {
+                send_heartbeat();
+            }
             last_time = _time.steady_time();
         }
 


### PR DESCRIPTION
My first pr to open source project.  Picked from github issues tagged with `beginner`  
 
**Fixes** #609 

Another solution is to invoke `_parent.is_connected()`  inside `SystemImpl::send_heartbeat()`, which I less preferred: only need to send heartbeats when the system is connected to remote devices. But let the project owner decide :) 

Tested with integration test `AUTOSTART_SITL=1 make run_integration_tests`: 

Before: 
```
[09:29:27|Info ] DronecodeSDK version: 0.14.1 (dronecode_sdk_impl.cpp:25)
[09:29:29|Debug] New: System ID: 0 Comp ID: 0 (dronecode_sdk_impl.cpp:285)
[09:29:29|Error] No known remotes (udp_connection.cpp:130)
[09:29:29|Error] send fail (dronecode_sdk_impl.cpp:91)
Waiting to be ready...
Waiting to be ready...
[09:29:30|Error] No known remotes (udp_connection.cpp:130)
[09:29:30|Error] send fail (dronecode_sdk_impl.cpp:91)
Waiting to be ready...
```

After:
```
[09:24:25|Info ] DronecodeSDK version: 0.14.1 (dronecode_sdk_impl.cpp:25)
[09:24:27|Debug] New: System ID: 0 Comp ID: 0 (dronecode_sdk_impl.cpp:285)
Waiting to be ready...
Waiting to be ready...
Waiting to be ready...
Waiting to be ready...
```