### PR TITLE
cmake: fix android build and update grpc dependencies

### DIFF
--- a/backend/cmake/third_party/boringssl/CMakeLists.txt
+++ b/backend/cmake/third_party/boringssl/CMakeLists.txt
@@ -5,7 +5,7 @@ project(external-boringssl)
 include(ExternalProject)
 
 set(ARG_GIT_REPOSITORY https://github.com/google/boringssl.git)
-set(ARG_GIT_TAG 38c20fe8d514a5328f5db404e116af8e9136c7f8)
+set(ARG_GIT_TAG 98ad4d77e372919980ae6cbcd19e928b8f80ce47)
 
 if(ANDROID)
     message(STATUS "Preparing external project \"boringssl\" for Android...")

--- a/backend/cmake/third_party/cares/CMakeLists.txt
+++ b/backend/cmake/third_party/cares/CMakeLists.txt
@@ -5,7 +5,7 @@ project(external-cares)
 include(ExternalProject)
 
 set(ARG_GIT_REPOSITORY https://github.com/c-ares/c-ares.git)
-set(ARG_GIT_TAG cares-1_13_0)
+set(ARG_GIT_TAG cares-1_15_0)
 
 if(ANDROID)
     message(STATUS "Preparing external project \"c-ares\" for Android...")

--- a/backend/cmake/third_party/grpc/CMakeLists.txt
+++ b/backend/cmake/third_party/grpc/CMakeLists.txt
@@ -5,7 +5,7 @@ project(external-grpc)
 include(ExternalProject)
 
 set(ARG_GIT_REPOSITORY https://github.com/dronecore/grpc.git)
-set(ARG_GIT_TAG enable-android-ios-build)
+set(ARG_GIT_TAG 16856-fix-codegen-off-install)
 
 # This answer probably saved me from destroying my computer:
 # https://stackoverflow.com/questions/45414507/pass-a-list-of-prefix-paths-to-externalproject-add-in-cmake-args

--- a/backend/cmake/third_party/protobuf/CMakeLists.txt
+++ b/backend/cmake/third_party/protobuf/CMakeLists.txt
@@ -5,7 +5,7 @@ project(external-protobuf)
 include(ExternalProject)
 
 set(ARG_GIT_REPOSITORY https://github.com/google/protobuf.git)
-set(ARG_GIT_TAG ab95b1bc1eb964ee5f1fb48297344c5d37d35191)
+set(ARG_GIT_TAG v3.6.1)
 
 if(ANDROID)
     message(STATUS "Preparing external project \"protobuf\" for Android...")

--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -5,10 +5,10 @@ set(SKIP_INSTALL_ALL "true")
 include_directories("${ZLIB_ROOT_DIR}")
 add_subdirectory(${ZLIB_ROOT_DIR} third_party/zlib)
 
-if(NOT ANDROID AND NOT IOS)
-    set_property(TARGET zlibstatic PROPERTY POSITION_INDEPENDENT_CODE ON)
-else()
+if(IOS)
     set_property(TARGET zlibstatic PROPERTY POSITION_INDEPENDENT_CODE OFF)
+else()
+    set_property(TARGET zlibstatic PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
 set(DRONECORE_ZLIB_LIBRARIES zlibstatic)


### PR DESCRIPTION
* For some reason, Android now needs zlib to be compiled with -fPIC.
* Update grpc dependencies (BoringSSL was failing to build on Android, and we were stuck on 1 year old dependencies :sweat_smile:)

Builds on linux (default + android), macOS (default, ios, ios_simulator), passes the unit tests and apparently runs the examples fine on linux and iPad (e.g. telemetry, takeoff and land, mission, ...).

Notes:

* Android-NDK r19b requires [this fix](https://android-review.googlesource.com/c/platform/ndk/+/907834) to build. It will come with r19c.
* Still pointing to https://github.com/dronecore/grpc, but [I opened a PR](https://github.com/grpc/grpc/pull/18151) that may help us go back to using upstream.