### PR TITLE
backend: remove warnings from protobuf-generated files

### DIFF
--- a/backend/test/CMakeLists.txt
+++ b/backend/test/CMakeLists.txt
@@ -18,8 +18,13 @@ target_include_directories(unit_tests_backend
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/plugins
     ${PROJECT_SOURCE_DIR}/plugins
-    ${CMAKE_BINARY_DIR}/backend/src
     ${PROJECT_SOURCE_DIR}
+)
+
+target_include_directories(unit_tests_backend
+    SYSTEM
+    PRIVATE
+    ${CMAKE_BINARY_DIR}/backend/src
 )
 
 target_link_libraries(unit_tests_backend


### PR DESCRIPTION
NOTE: That's apparently required only for the unit tests target, I'm not sure why it's not failing for the actual binary.