### PR TITLE
action: improve docs for goto altitude

### DIFF
--- a/plugins/action/include/plugins/action/action.h
+++ b/plugins/action/include/plugins/action/action.h
@@ -138,16 +138,15 @@ public:
     Result return_to_launch() const;
 
     /**
-     * @brief Send command to reposition the vehicle to a specific position.
+     * @brief Send command to move the vehicle to a specific global position.
      *
-     * The latitude and longitude is given in degrees in WGS84 and the altitude
+     * The latitude and longitude are given in degrees (WGS84 frame) and the altitude
      * in meters AMSL (above mean sea level).
      *
-     * This sends the vehicle to a specified lattitude/longitude/altitude coordinates.
-     * @param latitude_deg Latitude in degrees
-     * @param longitude_deg Longitude in degrees
-     * @param altitude_amsl_m Altitude AMSL in meters
-     * @param yaw_deg Yaw angle in degrees
+     * @param latitude_deg Latitude in degrees.
+     * @param longitude_deg Longitude in degrees.
+     * @param altitude_amsl_m Altitude AMSL in meters.
+     * @param yaw_deg Yaw angle in degrees (Frame is NED, 0 is North, positive is clockwise).
      *
      * @return Result of request.
      */

--- a/plugins/action/include/plugins/action/action.h
+++ b/plugins/action/include/plugins/action/action.h
@@ -138,7 +138,10 @@ public:
     Result return_to_launch() const;
 
     /**
-     * @brief Send command to reposition the vehicle to a specific WGS84 global position
+     * @brief Send command to reposition the vehicle to a specific position.
+     *
+     * The latitude and longitude is given in degrees in WGS84 and the altitude
+     * in meters AMSL (above mean sea level).
      *
      * This sends the vehicle to a specified lattitude/longitude/altitude coordinates.
      * @param latitude_deg Latitude in degrees


### PR DESCRIPTION
Currently, PX4 does not let us specifiy absolute altitudes for goto, so AMSL (above mean sea level) is all we have.

Closes #691.