### PR TITLE
core: get rid of termios2, use termios on Linux

### DIFF
--- a/core/include/dronecode_sdk/connection_result.h
+++ b/core/include/dronecode_sdk/connection_result.h
@@ -24,7 +24,8 @@ enum class ConnectionResult {
     COMMAND_DENIED, /**< @brief Command is denied. */
     DESTINATION_IP_UNKNOWN, /**< @brief %Connection IP is unknown. */
     CONNECTIONS_EXHAUSTED, /**< @brief %Connections exhausted. */
-    CONNECTION_URL_INVALID /**< @brief URL invalid. */
+    CONNECTION_URL_INVALID, /**< @brief URL invalid. */
+    BAUDRATE_UNKNOWN /**< @brief Baudrate unknown. */
 };
 
 /**
@@ -62,6 +63,8 @@ inline const char *connection_result_str(const ConnectionResult result)
             return "Connections exhausted";
         case ConnectionResult::CONNECTION_URL_INVALID:
             return "Invalid connection URL";
+        case ConnectionResult::BAUDRATE_UNKNOWN:
+            return "Baudrate unknown";
         default:
             return "Unknown";
     }

--- a/core/serial_connection.h
+++ b/core/serial_connection.h
@@ -30,16 +30,20 @@ private:
     void start_recv_thread();
     void receive();
 
+#if defined(LINUX)
+    static int define_from_baudrate(int baudrate);
+#endif
+
     std::string _serial_node;
     int _baudrate;
 
     std::mutex _mutex = {};
 #if !defined(WINDOWS)
     int _fd = -1;
-    static int define_from_baudrate(int baudrate);
 #else
     HANDLE _handle;
 #endif
+
     std::thread *_recv_thread = nullptr;
     std::atomic_bool _should_exit{false};
 };

--- a/core/serial_connection.h
+++ b/core/serial_connection.h
@@ -36,6 +36,7 @@ private:
     std::mutex _mutex = {};
 #if !defined(WINDOWS)
     int _fd = -1;
+    static int define_from_baudrate(int baudrate);
 #else
     HANDLE _handle;
 #endif


### PR DESCRIPTION
In order to simplify and to enable the build in manylinux1 it makes sense to go back to termios instead of termios2.