### PR TITLE
Allow users to test health component separately

### DIFF
--- a/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -475,6 +475,27 @@ public:
     Health health() const;
 
     /**
+     * @brief Returns true if gyroscope health is ok (synchronous).
+     *
+     * @return True if only gyroscope flags is OK.
+     */
+    bool health_gyrometer() const;
+
+    /**
+     * @brief Returns true if accelerometer health is ok (synchronous).
+     *
+     * @return True if only accelerometer flags is OK.
+     */
+    bool health_accelerometer() const;
+
+    /**
+     * @brief Returns true if magnetometer health is ok (synchronous).
+     *
+     * @return True if only magnetometer flags is OK.
+     */
+    bool health_magnetometer() const;
+
+    /**
      * @brief Returns true if the overall health is ok (synchronous).
      *
      * @return True if all health flags are OK.

--- a/plugins/telemetry/telemetry.cpp
+++ b/plugins/telemetry/telemetry.cpp
@@ -181,6 +181,21 @@ Telemetry::Health Telemetry::health() const
     return _impl->get_health();
 }
 
+bool Telemetry::health_gyrometer() const
+{
+    return _impl->get_health_gyrometer();
+}
+
+bool Telemetry::health_accelerometer() const
+{
+    return _impl->get_health_accelerometer();
+}
+
+bool Telemetry::health_magnetometer() const
+{
+    return _impl->get_health_magnetometer();
+}
+
 bool Telemetry::health_all_ok() const
 {
     return _impl->get_health_all_ok();

--- a/plugins/telemetry/telemetry_impl.cpp
+++ b/plugins/telemetry/telemetry_impl.cpp
@@ -759,6 +759,36 @@ Telemetry::Health TelemetryImpl::get_health() const
     return _health;
 }
 
+bool TelemetryImpl::get_health_gyrometer() const
+{
+    std::lock_guard<std::mutex> lock(_health_mutex);
+    if (_health.gyrometer_calibration_ok) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool TelemetryImpl::get_health_accelerometer() const
+{
+    std::lock_guard<std::mutex> lock(_health_mutex);
+    if (_health.accelerometer_calibration_ok) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool TelemetryImpl::get_health_magnetometer() const
+{
+    std::lock_guard<std::mutex> lock(_health_mutex);
+    if (_health.magnetometer_calibration_ok) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 bool TelemetryImpl::get_health_all_ok() const
 {
     std::lock_guard<std::mutex> lock(_health_mutex);

--- a/plugins/telemetry/telemetry_impl.h
+++ b/plugins/telemetry/telemetry_impl.h
@@ -63,6 +63,9 @@ public:
     Telemetry::Battery get_battery() const;
     Telemetry::FlightMode get_flight_mode() const;
     Telemetry::Health get_health() const;
+    bool get_health_gyrometer() const;
+    bool get_health_accelerometer() const;
+    bool get_health_magnetometer() const;
     bool get_health_all_ok() const;
     Telemetry::RCStatus get_rc_status() const;
 


### PR DESCRIPTION
Since the only way to know which prefilight check is
causing the problem is tp print the health struct, this way
will allow user to test each one separately without
print out the struct

Signed-off-by: Omar Shrit <shrit@lri.fr>