### PR TITLE
Add possibility to set an arbitrary acceptance radius 

### DIFF
--- a/plugins/mission/include/plugins/mission/mission_item.h
+++ b/plugins/mission/include/plugins/mission/mission_item.h
@@ -55,7 +55,8 @@ public:
     /**
      * @brief Set the acceptance radius property of a mission item.
      *
-     * @param radius_m Radius in meters around the mission_item where it will be considered as reached.
+     * @param radius_m Radius in meters around the mission_item where it will be considered as
+     * reached.
      */
     void set_acceptance_radius(float radius_m);
 

--- a/plugins/mission/include/plugins/mission/mission_item.h
+++ b/plugins/mission/include/plugins/mission/mission_item.h
@@ -53,6 +53,13 @@ public:
     void set_fly_through(bool fly_through);
 
     /**
+     * @brief Set the acceptance radius property of a mission item.
+     *
+     * @param radius Radius around the mission_item where it will be considered as reached
+     */
+    void set_acceptance_radius(float radius);
+
+    /**
      * @brief Set the speed to use after a mission item.
      *
      * @param speed_m_s Speed to use after this mission item in metres/second.
@@ -153,6 +160,13 @@ public:
      */
     bool get_fly_through() const;
 
+    /**
+     * @brief Get the acceptance radius of a mission item.
+     *
+     * @return Acceptance radius in meters
+     */
+    float get_acceptance_radius() const;
+    
     /**
      * @brief Get the speed to be used after this mission item.
      *

--- a/plugins/mission/include/plugins/mission/mission_item.h
+++ b/plugins/mission/include/plugins/mission/mission_item.h
@@ -57,7 +57,7 @@ public:
      *
      * @param radius Radius around the mission_item where it will be considered as reached
      */
-    void set_acceptance_radius(float radius);
+    void set_acceptance_radius(float radius_m);
 
     /**
      * @brief Set the speed to use after a mission item.
@@ -165,7 +165,7 @@ public:
      *
      * @return Acceptance radius in meters
      */
-    float get_acceptance_radius() const;
+    float get_acceptance_radius_m() const;
     
     /**
      * @brief Get the speed to be used after this mission item.

--- a/plugins/mission/include/plugins/mission/mission_item.h
+++ b/plugins/mission/include/plugins/mission/mission_item.h
@@ -166,7 +166,7 @@ public:
      * @return Acceptance radius in meters
      */
     float get_acceptance_radius_m() const;
-    
+
     /**
      * @brief Get the speed to be used after this mission item.
      *

--- a/plugins/mission/include/plugins/mission/mission_item.h
+++ b/plugins/mission/include/plugins/mission/mission_item.h
@@ -55,7 +55,7 @@ public:
     /**
      * @brief Set the acceptance radius property of a mission item.
      *
-     * @param radius Radius around the mission_item where it will be considered as reached
+     * @param radius_m Radius in meters around the mission_item where it will be considered as reached.
      */
     void set_acceptance_radius(float radius_m);
 
@@ -163,7 +163,7 @@ public:
     /**
      * @brief Get the acceptance radius of a mission item.
      *
-     * @return Acceptance radius in meters
+     * @return Acceptance radius in meters.
      */
     float get_acceptance_radius_m() const;
 

--- a/plugins/mission/mission_item.cpp
+++ b/plugins/mission/mission_item.cpp
@@ -34,6 +34,11 @@ void MissionItem::set_fly_through(bool fly_through)
     _impl->set_fly_through(fly_through);
 }
 
+void MissionItem::set_acceptance_radius(float radius)
+{
+    _impl->set_acceptance_radius(radius);
+}
+
 void MissionItem::set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg)
 {
     _impl->set_gimbal_pitch_and_yaw(pitch_deg, yaw_deg);
@@ -77,6 +82,11 @@ float MissionItem::get_relative_altitude_m() const
 bool MissionItem::get_fly_through() const
 {
     return _impl->get_fly_through();
+}
+
+float MissionItem::get_acceptance_radius() const
+{
+    return _impl->get_acceptance_radius();
 }
 
 float MissionItem::get_speed_m_s() const

--- a/plugins/mission/mission_item.cpp
+++ b/plugins/mission/mission_item.cpp
@@ -34,9 +34,9 @@ void MissionItem::set_fly_through(bool fly_through)
     _impl->set_fly_through(fly_through);
 }
 
-void MissionItem::set_acceptance_radius(float radius)
+void MissionItem::set_acceptance_radius(float radius_m)
 {
-    _impl->set_acceptance_radius(radius);
+    _impl->set_acceptance_radius(radius_m);
 }
 
 void MissionItem::set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg)
@@ -84,9 +84,9 @@ bool MissionItem::get_fly_through() const
     return _impl->get_fly_through();
 }
 
-float MissionItem::get_acceptance_radius() const
+float MissionItem::get_acceptance_radius_m() const
 {
-    return _impl->get_acceptance_radius();
+    return _impl->get_acceptance_radius_m();
 }
 
 float MissionItem::get_speed_m_s() const

--- a/plugins/mission/mission_item_impl.cpp
+++ b/plugins/mission/mission_item_impl.cpp
@@ -30,9 +30,9 @@ void MissionItemImpl::set_fly_through(bool fly_through)
     _fly_through = fly_through;
 }
 
-void MissionItemImpl::set_acceptance_radius(float radius)
+void MissionItemImpl::set_acceptance_radius(float radius_m)
 {
-    _acceptance_radius_m = radius;
+    _acceptance_radius_m = radius_m;
 }
 
 void MissionItemImpl::set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg)

--- a/plugins/mission/mission_item_impl.cpp
+++ b/plugins/mission/mission_item_impl.cpp
@@ -90,7 +90,7 @@ float MissionItemImpl::get_mavlink_param1() const
 float MissionItemImpl::get_mavlink_param2() const
 {
     float acceptance_radius_m;
-    if (_acceptance_radius_m) {
+    if (std::isfinite(_acceptance_radius_m)) {
         acceptance_radius_m = _acceptance_radius_m;
     } else if (_fly_through) {
         // _acceptance_radius_m is 0, determine the radius using fly_through

--- a/plugins/mission/mission_item_impl.cpp
+++ b/plugins/mission/mission_item_impl.cpp
@@ -30,6 +30,11 @@ void MissionItemImpl::set_fly_through(bool fly_through)
     _fly_through = fly_through;
 }
 
+void MissionItemImpl::set_acceptance_radius(float radius)
+{
+    _acceptance_radius_m = radius;
+}
+
 void MissionItemImpl::set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg)
 {
     _gimbal_pitch_deg = pitch_deg;
@@ -85,9 +90,13 @@ float MissionItemImpl::get_mavlink_param1() const
 float MissionItemImpl::get_mavlink_param2() const
 {
     float acceptance_radius_m;
-    if (_fly_through) {
+    if (_acceptance_radius_m) {
+        acceptance_radius_m = _acceptance_radius_m;
+    } else if (_fly_through) {
+        // _acceptance_radius_m is 0, determine the radius using fly_through
         acceptance_radius_m = 3.0f;
     } else {
+        // _acceptance_radius_m is 0, determine the radius using fly_through
         acceptance_radius_m = 1.0f;
     }
 

--- a/plugins/mission/mission_item_impl.h
+++ b/plugins/mission/mission_item_impl.h
@@ -50,7 +50,7 @@ private:
     float _relative_altitude_m = NAN;
     float _speed_m_s = NAN;
     bool _fly_through = false;
-    float _acceptance_radius_m = 0.0;
+    float _acceptance_radius_m = NAN;
     float _gimbal_pitch_deg = NAN;
     float _gimbal_yaw_deg = NAN;
     float _loiter_time_s = NAN;

--- a/plugins/mission/mission_item_impl.h
+++ b/plugins/mission/mission_item_impl.h
@@ -14,6 +14,7 @@ public:
     void set_relative_altitude(float relative_altitude_m);
     void set_speed(float speed_m_s);
     void set_fly_through(bool fly_through);
+    void set_acceptance_radius(float radius);
     void set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg);
     void set_loiter_time(float loiter_time_s);
     void set_camera_action(MissionItem::CameraAction action);
@@ -24,6 +25,7 @@ public:
     float get_relative_altitude_m() const { return _relative_altitude_m; }
     float get_speed_m_s() const { return _speed_m_s; }
     bool get_fly_through() const { return _fly_through; };
+    float get_acceptance_radius() const { return _acceptance_radius_m; };
     float get_gimbal_pitch_deg() const { return _gimbal_pitch_deg; }
     float get_gimbal_yaw_deg() const { return _gimbal_yaw_deg; }
     float get_loiter_time_s() const { return _loiter_time_s; }
@@ -48,6 +50,7 @@ private:
     float _relative_altitude_m = NAN;
     float _speed_m_s = NAN;
     bool _fly_through = false;
+    float _acceptance_radius_m = 0.0;
     float _gimbal_pitch_deg = NAN;
     float _gimbal_yaw_deg = NAN;
     float _loiter_time_s = NAN;

--- a/plugins/mission/mission_item_impl.h
+++ b/plugins/mission/mission_item_impl.h
@@ -14,7 +14,7 @@ public:
     void set_relative_altitude(float relative_altitude_m);
     void set_speed(float speed_m_s);
     void set_fly_through(bool fly_through);
-    void set_acceptance_radius(float radius);
+    void set_acceptance_radius(float radius_m);
     void set_gimbal_pitch_and_yaw(float pitch_deg, float yaw_deg);
     void set_loiter_time(float loiter_time_s);
     void set_camera_action(MissionItem::CameraAction action);
@@ -25,7 +25,7 @@ public:
     float get_relative_altitude_m() const { return _relative_altitude_m; }
     float get_speed_m_s() const { return _speed_m_s; }
     bool get_fly_through() const { return _fly_through; };
-    float get_acceptance_radius() const { return _acceptance_radius_m; };
+    float get_acceptance_radius_m() const { return _acceptance_radius_m; };
     float get_gimbal_pitch_deg() const { return _gimbal_pitch_deg; }
     float get_gimbal_yaw_deg() const { return _gimbal_yaw_deg; }
     float get_loiter_time_s() const { return _loiter_time_s; }


### PR DESCRIPTION
1. adds _acceptance_radius member variable to MissionItemImpl class
2. adds functions to set and get the acceptance radius
3. changes the get_mavlink_param2() function to return the acceptance radius if it is set,
   if it is not, it will return the predefined values (3 or 1 meter) depending on the _fly_through boolean, as it was before

Resolves #713.