### PR TITLE
mavlink_parameters: fix timeout for 16 char params

### DIFF
--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <string>
 #include <functional>
-#include <cstring> // for memcpy
 #include <cassert>
 #include <map>
 
@@ -509,6 +508,8 @@ private:
     void process_param_ext_value(const mavlink_message_t &message);
     void process_param_ext_ack(const mavlink_message_t &message);
     void receive_timeout();
+
+    static std::string extract_safe_param_id(const char param_id[]);
 
     SystemImpl &_parent;
 

--- a/plugins/log_files/log_files_impl.cpp
+++ b/plugins/log_files/log_files_impl.cpp
@@ -3,6 +3,7 @@
 #include "dronecode_sdk_impl.h"
 #include <fstream>
 #include <ctime>
+#include <cstring>
 
 namespace dronecode_sdk {
 


### PR DESCRIPTION
This fixes a char array overflow in strlen in string compare. This happened because the case where the MAVLink param name has length 16 and is not handled correctly. The MAVLink field is not 0 terminated which means that we need to copy to bytes to a 0 terminated buffer first before using it.

Thanks for reporting @douglaswsilva!