### PR TITLE
Adding attitude control too off board.

### DIFF
--- a/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/plugins/offboard/include/plugins/offboard/offboard.h
@@ -106,15 +106,14 @@ public:
     };
 
     /**
-       * @brief Type for attitude commands in NED coordinates (forward, right, down and yaw angular
-       * rate).
+       * @brief Type for attitude commands in NED coordinates (roll, pitch, yaw and thrust
        */
       struct Attitude {
           float roll_deg; /**< @brief attitude in deg. */
           float pitch_deg; /**< @brief attitude in deg */
           float yaw_deg; /**< @brief attitude in deg */
-          float thrust_value; /**< @brief Yaw angular rate in degrees/second (positive for
-                                   clock-wise looking from above). */
+          float thrust_value; /**< @brief Thrust in percentage ranging from 0 to 1 ( 0 to 100
+                                 percent). */
       };
 
     /**
@@ -200,10 +199,10 @@ public:
     void set_velocity_body(VelocityBodyYawspeed velocity_body_yawspeed);
 
     /**
-     * @brief Set the attitude rate in terms of pitch, roll and yaw angular rate along with thrust
+     * @brief Set the attitude in terms of roll, pitch and yaw in degrees with thrust
      * in percentage.
      *
-     * @param attitude_rate roll, pitch and yaw angular rate along with thrust in percentage.
+     * @param attitude roll, pitch and yaw in degrees along with thrust in percentage.
      */
 
     void set_attitude(Attitude attitude);

--- a/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/plugins/offboard/include/plugins/offboard/offboard.h
@@ -106,7 +106,7 @@ public:
     };
 
     /**
-     * @brief Type for attitude commands in NED coordinates (roll, pitch, yaw and thrust
+     * @brief Type for attitude body angles in NED reference frame (roll, pitch, yaw and thrust)
      */
     struct Attitude {
         float roll_deg; /**< @brief Roll angle in degrees (positive is right side down). */

--- a/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/plugins/offboard/include/plugins/offboard/offboard.h
@@ -106,6 +106,18 @@ public:
     };
 
     /**
+       * @brief Type for attitude commands in NED coordinates (forward, right, down and yaw angular
+       * rate).
+       */
+      struct Attitude {
+          float roll_deg; /**< @brief attitude in deg. */
+          float pitch_deg; /**< @brief attitude in deg */
+          float yaw_deg; /**< @brief attitude in deg */
+          float thrust_value; /**< @brief Yaw angular rate in degrees/second (positive for
+                                   clock-wise looking from above). */
+      };
+
+    /**
      * @brief Type for Attitude rate commands in body coordinates (roll, pitch, yaw  angular
      * rate and Thrust).
      */
@@ -193,6 +205,15 @@ public:
      *
      * @param attitude_rate roll, pitch and yaw angular rate along with thrust in percentage.
      */
+
+    void set_attitude(Attitude attitude);
+
+   /**
+    * @brief Set the attitude rate in terms of pitch, roll and yaw angular rate along with thrust
+    * in percentage.
+    *
+    * @param attitude_rate roll, pitch and yaw angular rate along with thrust in percentage.
+    */
     void set_attitude_rate(AttitudeRate attitude_rate);
 
     /**

--- a/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/plugins/offboard/include/plugins/offboard/offboard.h
@@ -106,15 +106,15 @@ public:
     };
 
     /**
-       * @brief Type for attitude commands in NED coordinates (roll, pitch, yaw and thrust
-       */
-      struct Attitude {
-          float roll_deg; /**< @brief attitude in deg. */
-          float pitch_deg; /**< @brief attitude in deg */
-          float yaw_deg; /**< @brief attitude in deg */
-          float thrust_value; /**< @brief Thrust in percentage ranging from 0 to 1 ( 0 to 100
-                                 percent). */
-      };
+     * @brief Type for attitude commands in NED coordinates (roll, pitch, yaw and thrust
+     */
+    struct Attitude {
+        float roll_deg; /**< @brief attitude in deg. */
+        float pitch_deg; /**< @brief attitude in deg */
+        float yaw_deg; /**< @brief attitude in deg */
+        float thrust_value; /**< @brief Thrust in percentage ranging from 0 to 1 ( 0 to 100
+                               percent). */
+    };
 
     /**
      * @brief Type for Attitude rate commands in body coordinates (roll, pitch, yaw  angular
@@ -207,12 +207,12 @@ public:
 
     void set_attitude(Attitude attitude);
 
-   /**
-    * @brief Set the attitude rate in terms of pitch, roll and yaw angular rate along with thrust
-    * in percentage.
-    *
-    * @param attitude_rate roll, pitch and yaw angular rate along with thrust in percentage.
-    */
+    /**
+     * @brief Set the attitude rate in terms of pitch, roll and yaw angular rate along with thrust
+     * in percentage.
+     *
+     * @param attitude_rate roll, pitch and yaw angular rate along with thrust in percentage.
+     */
     void set_attitude_rate(AttitudeRate attitude_rate);
 
     /**

--- a/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/plugins/offboard/include/plugins/offboard/offboard.h
@@ -109,9 +109,9 @@ public:
      * @brief Type for attitude commands in NED coordinates (roll, pitch, yaw and thrust
      */
     struct Attitude {
-        float roll_deg; /**< @brief attitude in deg. */
-        float pitch_deg; /**< @brief attitude in deg */
-        float yaw_deg; /**< @brief attitude in deg */
+        float roll_deg; /**< @brief Roll angle in degrees (positive is right side down). */
+        float pitch_deg; /**< @brief Pitch angle in degrees (positive is nose up). */
+        float yaw_deg; /**< @brief Yaw in degrees (positive is move nose to the right). */
         float thrust_value; /**< @brief Thrust in percentage ranging from 0 to 1 ( 0 to 100
                                percent). */
     };
@@ -204,7 +204,6 @@ public:
      *
      * @param attitude roll, pitch and yaw in degrees along with thrust in percentage.
      */
-
     void set_attitude(Attitude attitude);
 
     /**

--- a/plugins/offboard/offboard.cpp
+++ b/plugins/offboard/offboard.cpp
@@ -47,6 +47,11 @@ void Offboard::set_velocity_body(Offboard::VelocityBodyYawspeed velocity_body_ya
     return _impl->set_velocity_body(velocity_body_yawspeed);
 }
 
+void Offboard::set_attitude(Offboard::Attitude attitude)
+{
+    return _impl->set_attitude(attitude);
+}
+
 void Offboard::set_attitude_rate(Offboard::AttitudeRate attitude_rate)
 {
     return _impl->set_attitude_rate(attitude_rate);

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -187,7 +187,6 @@ void OffboardImpl::set_velocity_body(Offboard::VelocityBodyYawspeed velocity_bod
     send_velocity_body();
 }
 
-
 void OffboardImpl::set_attitude(Offboard::Attitude attitude)
 {
     _mutex.lock();
@@ -214,7 +213,6 @@ void OffboardImpl::set_attitude(Offboard::Attitude attitude)
     // also send it right now to reduce latency
     send_attitude();
 }
-
 
 void OffboardImpl::set_attitude_rate(Offboard::AttitudeRate attitude_rate)
 {
@@ -420,7 +418,6 @@ void OffboardImpl::send_attitude()
     const float yaw = to_rad_from_deg(_attitude.yaw_deg);
     _mutex.unlock();
 
-
     const double cos_phi_2 = cos(double(roll) / 2.0);
     const double sin_phi_2 = sin(double(roll) / 2.0);
     const double cos_theta_2 = cos(double(pitch) / 2.0);
@@ -451,7 +448,6 @@ void OffboardImpl::send_attitude()
         thrust);
     _parent->send_message(message);
 }
-
 
 void OffboardImpl::send_attitude_rate()
 {

--- a/plugins/offboard/offboard_impl.cpp
+++ b/plugins/offboard/offboard_impl.cpp
@@ -187,6 +187,35 @@ void OffboardImpl::set_velocity_body(Offboard::VelocityBodyYawspeed velocity_bod
     send_velocity_body();
 }
 
+
+void OffboardImpl::set_attitude(Offboard::Attitude attitude)
+{
+    _mutex.lock();
+    _attitude = attitude;
+
+    if (_mode != Mode::ATTITUDE) {
+        if (_call_every_cookie) {
+            // If we're already sending other setpoints, stop that now.
+            _parent->remove_call_every(_call_every_cookie);
+            _call_every_cookie = nullptr;
+        }
+        // We automatically send body setpoints from now on.
+        _parent->add_call_every(
+            [this]() { send_attitude(); }, SEND_INTERVAL_S, &_call_every_cookie);
+
+        _mode = Mode::ATTITUDE;
+    } else {
+        // We're already sending these kind of setpoints. Since the setpoint change, let's
+        // reschedule the next call, so we don't send setpoints too often.
+        _parent->reset_call_every(_call_every_cookie);
+    }
+    _mutex.unlock();
+
+    // also send it right now to reduce latency
+    send_attitude();
+}
+
+
 void OffboardImpl::set_attitude_rate(Offboard::AttitudeRate attitude_rate)
 {
     _mutex.lock();
@@ -372,6 +401,57 @@ void OffboardImpl::send_velocity_body()
         yaw_rate);
     _parent->send_message(message);
 }
+
+void OffboardImpl::send_attitude()
+{
+    const static uint8_t IGNORE_BODY_ROLL_RATE = (1 << 0);
+    const static uint8_t IGNORE_BODY_PITCH_RATE = (1 << 1);
+    const static uint8_t IGNORE_BODY_YAW_RATE = (1 << 2);
+    // const static uint8_t IGNORE_4 = (1 << 3);
+    // const static uint8_t IGNORE_5 = (1 << 4);
+    // const static uint8_t IGNORE_6 = (1 << 5);
+    // const static uint8_t IGNORE_THRUST = (1 << 6);
+    // const static uint8_t IGNORE_ATTITUDE = (1 << 7);
+
+    _mutex.lock();
+    const float thrust = _attitude.thrust_value;
+    const float roll = to_rad_from_deg(_attitude.roll_deg);
+    const float pitch = to_rad_from_deg(_attitude.pitch_deg);
+    const float yaw = to_rad_from_deg(_attitude.yaw_deg);
+    _mutex.unlock();
+
+
+    const double cos_phi_2 = cos(double(roll) / 2.0);
+    const double sin_phi_2 = sin(double(roll) / 2.0);
+    const double cos_theta_2 = cos(double(pitch) / 2.0);
+    const double sin_theta_2 = sin(double(pitch) / 2.0);
+    const double cos_psi_2 = cos(double(yaw) / 2.0);
+    const double sin_psi_2 = sin(double(yaw) / 2.0);
+
+    float q[4];
+
+    q[0] = float(cos_phi_2 * cos_theta_2 * cos_psi_2 + sin_phi_2 * sin_theta_2 * sin_psi_2);
+    q[1] = float(sin_phi_2 * cos_theta_2 * cos_psi_2 - cos_phi_2 * sin_theta_2 * sin_psi_2);
+    q[2] = float(cos_phi_2 * sin_theta_2 * cos_psi_2 + sin_phi_2 * cos_theta_2 * sin_psi_2);
+    q[3] = float(cos_phi_2 * cos_theta_2 * sin_psi_2 - sin_phi_2 * sin_theta_2 * cos_psi_2);
+
+    mavlink_message_t message;
+    mavlink_msg_set_attitude_target_pack(
+        _parent->get_own_system_id(),
+        _parent->get_own_component_id(),
+        &message,
+        static_cast<uint32_t>(_parent->get_time().elapsed_s() * 1e3),
+        _parent->get_system_id(),
+        _parent->get_autopilot_id(),
+        IGNORE_BODY_ROLL_RATE | IGNORE_BODY_PITCH_RATE | IGNORE_BODY_YAW_RATE,
+        q,
+        0,
+        0,
+        0,
+        thrust);
+    _parent->send_message(message);
+}
+
 
 void OffboardImpl::send_attitude_rate()
 {

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -43,7 +43,6 @@ private:
     void send_attitude_rate();
     void send_attitude();
 
-
     void process_heartbeat(const mavlink_message_t &message);
     void receive_command_result(MAVLinkCommands::Result result,
                                 const Offboard::result_callback_t &callback);

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -30,6 +30,7 @@ public:
     void set_position_ned(Offboard::PositionNEDYaw position_ned_yaw);
     void set_velocity_ned(Offboard::VelocityNEDYaw velocity_ned_yaw);
     void set_velocity_body(Offboard::VelocityBodyYawspeed velocity_body_yawspeed);
+    void set_attitude(Offboard::Attitude attitude);
     void set_attitude_rate(Offboard::AttitudeRate attitude_rate);
 
     OffboardImpl(const OffboardImpl &) = delete;

--- a/plugins/offboard/offboard_impl.h
+++ b/plugins/offboard/offboard_impl.h
@@ -40,6 +40,8 @@ private:
     void send_velocity_ned();
     void send_velocity_body();
     void send_attitude_rate();
+    void send_attitude();
+
 
     void process_heartbeat(const mavlink_message_t &message);
     void receive_command_result(MAVLinkCommands::Result result,
@@ -55,11 +57,13 @@ private:
         POSITION_NED,
         VELOCITY_NED,
         VELOCITY_BODY,
+        ATTITUDE,
         ATTITUDE_RATE
     } _mode = Mode::NOT_ACTIVE;
     Offboard::PositionNEDYaw _position_ned_yaw{};
     Offboard::VelocityNEDYaw _velocity_ned_yaw{};
     Offboard::VelocityBodyYawspeed _velocity_body_yawspeed{};
+    Offboard::Attitude _attitude{};
     Offboard::AttitudeRate _attitude_rate{};
 
     void *_call_every_cookie = nullptr;


### PR DESCRIPTION
Wanted to include the attitude control in off board mode.

It's implemented. The test is currently included in the offboard_velocity example. 

One could consider renaming and modifying the offboard_velocity example to be called offboard and include attitude_rate as well.

Was unsure about the naming of Attitude, should it be Attitude_ned?

Resolves #473.
