### PR TITLE
core: fix MSVC compiler error

### DIFF
--- a/core/locked_queue.h
+++ b/core/locked_queue.h
@@ -24,11 +24,11 @@ public:
     }
 
     using iterator = typename std::deque<std::shared_ptr<T>>::iterator;
-    LockedQueue<T>::iterator begin() { return _queue.begin(); }
+    iterator begin() { return _queue.begin(); }
 
-    LockedQueue<T>::iterator end() { return _queue.end(); }
+    iterator end() { return _queue.end(); }
 
-    LockedQueue<T>::iterator erase(LockedQueue<T>::iterator it) { return _queue.erase(it); }
+    iterator erase(iterator it) { return _queue.erase(it); }
 
     class Guard {
     public:


### PR DESCRIPTION
Somehow, on one machine these changes were needed in order to avoid MSVC complaining about:
```
warning C4346: 'iterator': dependent name is not a type
```