### PR TITLE
core: hack to ignore messages from QGC for now

### DIFF
--- a/core/udp_connection.cpp
+++ b/core/udp_connection.cpp
@@ -206,7 +206,8 @@ void UdpConnection::receive()
         while (_mavlink_receiver->parse_message()) {
             const uint8_t sysid = _mavlink_receiver->get_last_message().sysid;
 
-            if (!saved_remote && sysid != 0) {
+            // FIXME: We ignore messages from QGC (255) for now.
+            if (!saved_remote && sysid != 0 && sysid != 255) {
                 saved_remote = true;
 
                 std::lock_guard<std::mutex> lock(_remote_mutex);


### PR DESCRIPTION
If we don't ignore the heartbeats from QGC we keep getting the warning that the remote changed on every heartbeat. Eventually we probably need a proper routing fix but this should do for now.

FYI @DanielePettenuzzo