### PR TITLE
core: fix deprecated-copy warning in GCC 9

### DIFF
--- a/core/mavlink_parameters.h
+++ b/core/mavlink_parameters.h
@@ -24,9 +24,15 @@ public:
     public:
         typedef char custom_type_t[128];
 
-        ParamValue &operator=(ParamValue value)
+        ParamValue() {}
+
+        ParamValue(ParamValue &rhs) { _value = rhs._value; }
+
+        ParamValue(const ParamValue &rhs) { _value = rhs._value; }
+
+        ParamValue &operator=(ParamValue rhs)
         {
-            _value = value._value;
+            _value = rhs._value;
             return *this;
         }
 


### PR DESCRIPTION
This fixes the warning that appeared with GCC 9:

```
core/system_impl.cpp:877:73: error:
implicitly-declared
‘dronecode_sdk::MAVLinkParameters::ParamValue::ParamValue(const
dronecode_sdk::MAVLinkParameters::ParamValue&)’ is deprecated
[-Werror=deprecated-copy]
```

Fedora 30 says hi :smile:!