### PR TITLE
integration_tests: fix failing mission transfer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ clone_folder: C:\dronecode_sdk
 before_build:
 
   - cd C:\dronecode_sdk
-  - git submodule update --init --recursive --depth 100
+  - git submodule update --init --recursive --depth 200
   - cd C:\
   - appveyor DownloadFile https://curl.haxx.se/download/curl-7.64.1.zip
   - 7z x -y curl-7.64.1.zip


### PR DESCRIPTION
- The timing checks are relaxed because they were too strict.
- Only mission transfer messages are filtered which should lead to more  consistent test results because other (high rate) messages won't  impact the mission transfers.

Should fix CI in #724.